### PR TITLE
Fix/Improve keyboard navigation for login dialog

### DIFF
--- a/src/app/components/login/login.rs
+++ b/src/app/components/login/login.rs
@@ -11,7 +11,7 @@ use crate::app::AppEvent;
 
 use super::LoginModel;
 
-const KEY_RETURN: u32 = 65293;
+const SUBMIT_KEY: &str = "Return";
 
 pub struct Login {
     dialog: gtk::Dialog,
@@ -25,20 +25,19 @@ fn handle_keypress(
     model: Rc<LoginModel>,
     event: &EventKey,
 ) -> Inhibit {
-    match event.get_keyval().to_glib() {
-        KEY_RETURN => {
-            let username_text = username.get_text().as_str().to_string();
-            let password_text = password.get_text().as_str().to_string();
-            if username_text.is_empty() {
-                username.grab_focus();
-            } else if password_text.is_empty() {
-                password.grab_focus();
-            } else {
-                model.login(username_text, password_text);
-            }
-            Inhibit(true)
+    if event.get_keyval().to_glib() == gdk::keyval_from_name(SUBMIT_KEY) {
+        let username_text = username.get_text().as_str().to_string();
+        let password_text = password.get_text().as_str().to_string();
+        if username_text.is_empty() {
+            username.grab_focus();
+        } else if password_text.is_empty() {
+            password.grab_focus();
+        } else {
+            model.login(username_text, password_text);
         }
-        _ => Inhibit(false),
+        Inhibit(true)
+    } else {
+        Inhibit(false)
     }
 }
 

--- a/src/app/components/login/login.rs
+++ b/src/app/components/login/login.rs
@@ -29,9 +29,9 @@ fn handle_keypress(
         KEY_RETURN => {
             let username_text = username.get_text().as_str().to_string();
             let password_text = password.get_text().as_str().to_string();
-            if username_text.len() == 0 {
+            if username_text.is_empty() {
                 username.grab_focus();
-            } else if password_text.len() == 0 {
+            } else if password_text.is_empty() {
                 password.grab_focus();
             } else {
                 model.login(username_text, password_text);

--- a/src/app/components/login/login.rs
+++ b/src/app/components/login/login.rs
@@ -23,7 +23,7 @@ fn handle_keypress(
     username: gtk::Entry,
     password: gtk::Entry,
     model: Rc<LoginModel>,
-    event: &EventKey
+    event: &EventKey,
 ) -> Inhibit {
     match event.get_keyval().to_glib() {
         KEY_RETURN => {
@@ -37,7 +37,7 @@ fn handle_keypress(
                 model.login(username_text, password_text);
             }
             gtk::Inhibit(true)
-        },
+        }
         _ => gtk::Inhibit(false),
     }
 }

--- a/src/app/components/login/login.rs
+++ b/src/app/components/login/login.rs
@@ -36,9 +36,9 @@ fn handle_keypress(
             } else {
                 model.login(username_text, password_text);
             }
-            gtk::Inhibit(true)
+            Inhibit(true)
         }
-        _ => gtk::Inhibit(false),
+        _ => Inhibit(false),
     }
 }
 
@@ -60,22 +60,22 @@ impl Login {
             }),
         );
         username.connect_key_press_event(
-            clone!(@weak username, @weak password, @weak model => @default-return gtk::Inhibit(false), move |_, event | {
+            clone!(@weak username, @weak password, @weak model => @default-return Inhibit(false), move |_, event | {
                 handle_keypress(username, password, model, event)
             }),
         );
         password.connect_key_press_event(
-            clone!(@weak username, @weak password, @weak model => @default-return gtk::Inhibit(false), move |_, event | {
+            clone!(@weak username, @weak password, @weak model => @default-return Inhibit(false), move |_, event | {
                 handle_keypress(username, password, model, event)
             }),
         );
 
         dialog.connect_delete_event(
-            clone!(@weak parent => @default-return gtk::Inhibit(false), move |_, _| {
+            clone!(@weak parent => @default-return Inhibit(false), move |_, _| {
                 if let Some(app) = parent.get_application().as_ref() {
                     app.quit();
                 }
-                gtk::Inhibit(true)
+                Inhibit(true)
             }),
         );
 

--- a/src/app/components/login/login.rs
+++ b/src/app/components/login/login.rs
@@ -2,7 +2,7 @@ use gdk::EventKey;
 use gio::ApplicationExt;
 use glib::translate::ToGlib;
 use gtk::prelude::*;
-use gtk::{EntryExt, GtkWindowExt, WidgetExt};
+use gtk::{GtkWindowExt, WidgetExt};
 use std::rc::Rc;
 
 use crate::app::components::EventListener;
@@ -26,15 +26,7 @@ fn handle_keypress(
     event: &EventKey,
 ) -> Inhibit {
     if event.get_keyval().to_glib() == gdk::keyval_from_name(SUBMIT_KEY) {
-        let username_text = username.get_text().as_str().to_string();
-        let password_text = password.get_text().as_str().to_string();
-        if username_text.is_empty() {
-            username.grab_focus();
-        } else if password_text.is_empty() {
-            password.grab_focus();
-        } else {
-            model.login(username_text, password_text);
-        }
+        model.submit_login_form(username, password);
         Inhibit(true)
     } else {
         Inhibit(false)
@@ -53,9 +45,7 @@ impl Login {
         let model = Rc::new(model);
         login_btn.connect_clicked(
             clone!(@weak username, @weak password,  @weak model => move |_| {
-                let username = username.get_text().as_str().to_string();
-                let password = password.get_text().as_str().to_string();
-                model.login(username, password);
+                model.submit_login_form(username, password);
             }),
         );
         username.connect_key_press_event(

--- a/src/app/components/login/login.rs
+++ b/src/app/components/login/login.rs
@@ -1,8 +1,8 @@
+use gdk::EventKey;
 use gio::ApplicationExt;
+use glib::translate::ToGlib;
 use gtk::prelude::*;
 use gtk::{EntryExt, GtkWindowExt, WidgetExt};
-use gdk::EventKey;
-use glib::translate::ToGlib;
 use std::rc::Rc;
 
 use crate::app::components::EventListener;
@@ -19,22 +19,27 @@ pub struct Login {
     model: Rc<LoginModel>,
 }
 
-fn handle_keypress(username: gtk::Entry, password: gtk::Entry, model: Rc<LoginModel>, event: &EventKey) -> Inhibit {
+fn handle_keypress(
+    username: gtk::Entry,
+    password: gtk::Entry,
+    model: Rc<LoginModel>,
+    event: &EventKey
+) -> Inhibit {
     match event.get_keyval().to_glib() {
-    KEY_RETURN => {
-        let username_text = username.get_text().as_str().to_string();
-        let password_text = password.get_text().as_str().to_string();
-        if username_text.len() == 0 {
-            username.grab_focus();
-        } else if password_text.len() == 0 {
-            password.grab_focus();
-        } else {
-            model.login(username_text, password_text);
-        }
-        gtk::Inhibit(true)
-    },
-    _ => gtk::Inhibit(false),
-}
+        KEY_RETURN => {
+            let username_text = username.get_text().as_str().to_string();
+            let password_text = password.get_text().as_str().to_string();
+            if username_text.len() == 0 {
+                username.grab_focus();
+            } else if password_text.len() == 0 {
+                password.grab_focus();
+            } else {
+                model.login(username_text, password_text);
+            }
+            gtk::Inhibit(true)
+        },
+        _ => gtk::Inhibit(false),
+    }
 }
 
 impl Login {

--- a/src/app/components/login/login_model.rs
+++ b/src/app/components/login/login_model.rs
@@ -1,5 +1,3 @@
-use gtk::{EntryExt, WidgetExt};
-
 use crate::app::credentials;
 use crate::app::{ActionDispatcher, AppAction};
 
@@ -32,17 +30,5 @@ impl LoginModel {
 
     pub fn login(&self, u: String, p: String) {
         self.dispatcher.dispatch(AppAction::TryLogin(u, p));
-    }
-
-    pub fn submit_login_form(&self, username: gtk::Entry, password: gtk::Entry) {
-        let username_text = username.get_text().as_str().to_string();
-        let password_text = password.get_text().as_str().to_string();
-        if username_text.is_empty() {
-            username.grab_focus();
-        } else if password_text.is_empty() {
-            password.grab_focus();
-        } else {
-            self.login(username_text, password_text);
-        }
     }
 }

--- a/src/app/components/login/login_model.rs
+++ b/src/app/components/login/login_model.rs
@@ -1,3 +1,5 @@
+use gtk::{EntryExt, WidgetExt};
+
 use crate::app::credentials;
 use crate::app::{ActionDispatcher, AppAction};
 
@@ -30,5 +32,17 @@ impl LoginModel {
 
     pub fn login(&self, u: String, p: String) {
         self.dispatcher.dispatch(AppAction::TryLogin(u, p));
+    }
+
+    pub fn submit_login_form(&self, username: gtk::Entry, password: gtk::Entry) {
+        let username_text = username.get_text().as_str().to_string();
+        let password_text = password.get_text().as_str().to_string();
+        if username_text.is_empty() {
+            username.grab_focus();
+        } else if password_text.is_empty() {
+            password.grab_focus();
+        } else {
+            self.login(username_text, password_text);
+        }
     }
 }

--- a/src/window.ui
+++ b/src/window.ui
@@ -349,7 +349,7 @@
                 <child>
                   <object class="GtkToggleButton" id="shuffle">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="halign">end</property>
                     <property name="valign">center</property>
@@ -512,7 +512,7 @@ Douile</property>
     </child>
   </object>
   <object class="GtkDialog" id="login">
-    <property name="can-focus">True</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Spot</property>
     <property name="modal">True</property>
     <property name="window-position">center-on-parent</property>
@@ -522,7 +522,7 @@ Douile</property>
     <property name="transient-for">window</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="can-focus">True</property>
+        <property name="can-focus">False</property>
         <property name="margin-start">8</property>
         <property name="margin-end">8</property>
         <property name="margin-top">8</property>


### PR DESCRIPTION
This PR fixes tab navigation not working on the login dialog. It also allows the user to submit the login form by pressing return.

Some notes:
- In the key-press handler I added some logic that auto focuses the username or password entry if they are empty. I wasn't sure whether this should go in `LoginModel::login`
  - I also think this should give some user feedback, i.e. logs in but password is empty, then password box is highlighted red and focused. But I don't know how to do this
- The key-press should probably be a method but I wasn't sure where was best to put it.

Fixes #70 