### PR TITLE
Take buildtype into account when testing

### DIFF
--- a/build-aux/test.sh
+++ b/build-aux/test.sh
@@ -2,10 +2,19 @@
 
 export SRC="$1"
 export CARGO_TARGET_DIR="$2"/target
-export OFFLINE="$3"
+export BUILDTYPE="$3"
+export OFFLINE="$4"
+
+echo $BUILDTYPE
+
+if [[ $BUILDTYPE = "release" ]]; then
+    PROFILE_ARG="--release"
+else
+    PROFILE_ARG="--verbose"
+fi
 
 if [[ $OFFLINE = "true" ]]; then
     export CARGO_HOME="$SRC"/cargo
 fi
 
-cargo test --manifest-path "$SRC"/Cargo.toml
+cargo test --manifest-path "$SRC"/Cargo.toml "$PROFILE_ARG"

--- a/src/meson.build
+++ b/src/meson.build
@@ -140,6 +140,7 @@ test('Unit tests',
   args: [
     meson.source_root(),
     meson.build_root(),
+    get_option('buildtype'),
     get_option('offline') ? 'true' : 'false'
   ]
 )


### PR DESCRIPTION
This prevents cargo from recompiling when running tests on a release build.