### PR TITLE
Github Actions: Add shellcheck

### DIFF
--- a/.github/workflows/spot-quality.yml
+++ b/.github/workflows/spot-quality.yml
@@ -2,6 +2,7 @@ name: spot-quality
 
 on:
   push:
+  pull_request:
 
 jobs:
   ci-check:

--- a/.github/workflows/spot-quality.yml
+++ b/.github/workflows/spot-quality.yml
@@ -21,3 +21,11 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  shellcheck:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+            sudo apt-get -y update && sudo apt-get -y install shellcheck
+            find $GITHUB_WORKSPACE -type f -and \( -name "*.sh" \) | xargs shellcheck

--- a/build-aux/cargo.sh
+++ b/build-aux/cargo.sh
@@ -8,7 +8,7 @@ export BUILDTYPE="$5"
 export FEATURES="$6"
 export OFFLINE="$7"
 
-echo $BUILDTYPE
+echo "$BUILDTYPE"
 
 if [[ $BUILDTYPE = "release" ]]; then
     OUTPUT_BIN="$CARGO_TARGET_DIR"/release/"$APP_BIN"

--- a/build-aux/test.sh
+++ b/build-aux/test.sh
@@ -5,7 +5,7 @@ export CARGO_TARGET_DIR="$2"/target
 export BUILDTYPE="$3"
 export OFFLINE="$4"
 
-echo $BUILDTYPE
+echo "$BUILDTYPE"
 
 if [[ $BUILDTYPE = "release" ]]; then
     PROFILE_ARG="--release"


### PR DESCRIPTION
This PR adds [shellcheck](https://github.com/koalaman/shellcheck) to the automatic testing on push.
There were almost no problems with the `sh` files, but I think it's better safe than sorry, isn't it? :wink: