### PR TITLE
Add further meson dependency checks

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,8 @@
 pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
 gnome = import('gnome')
 dependency('libhandy-1')
+dependency('gtk+-3.0')
+dependency('glib-2.0')
 dependency('openssl')
 dependency('alsa')
 dependency('libpulse')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,9 @@
 pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
 gnome = import('gnome')
 dependency('libhandy-1')
+dependency('openssl')
+dependency('alsa')
+dependency('libpulse')
 
 gnome.compile_resources('spot',
   'spot.gresource.xml',


### PR DESCRIPTION
I ran into missing openssl in the build stage, so I added some further dependency checks. Is alsa a required dependency?