### PR TITLE
Update spanish translation

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -47,7 +47,7 @@ msgstr "Cerrar sesión"
 #. translators: This is a sidebar entry to browse to saved albums.
 #: src/app/components/navigation/home.rs:33
 msgid "Library"
-msgstr "Libreria"
+msgstr "Biblioteca"
 
 #. translators: This is a sidebar entry to browse to saved playlists.
 #: src/app/components/navigation/home.rs:38


### PR DESCRIPTION
Use "Biblioteca" for "library", in the same way as the official Spotify client does.