### PR TITLE
Fix MPRIS seek command

### DIFF
--- a/src/app/components/playback/playback_control.rs
+++ b/src/app/components/playback/playback_control.rs
@@ -213,7 +213,8 @@ impl EventListener for PlaybackControl {
                 self.update_playing();
                 self.update_current_info();
             }
-            AppEvent::PlaybackEvent(PlaybackEvent::SeekSynced(pos)) => {
+            AppEvent::PlaybackEvent(PlaybackEvent::SeekSynced(pos))
+            | AppEvent::PlaybackEvent(PlaybackEvent::TrackSeeked(pos)) => {
                 self.sync_seek(*pos);
             }
             _ => {}


### PR DESCRIPTION
This PR contains a few fixes:
- Allows negative seeking (backwards)
- Makes the seek command follow spec
  - If seeking to < 0 round to 0
  - If seeking past end of song skip the song ( this already worked as quirk of internals, but added concrete implementation)
- Updates the UI if you seek with MPRIS while the song is paused