### PR TITLE
Fix "from_over_into" clippy warnings

### DIFF
--- a/src/api/api_models.rs
+++ b/src/api/api_models.rs
@@ -226,17 +226,17 @@ pub struct RawSearchResults {
     pub artists: Option<Page<Artist>>,
 }
 
-impl Into<ArtistSummary> for Artist {
-    fn into(self) -> ArtistSummary {
-        let photo = self.best_image_for_width(200).map(|i| &i.url).cloned();
-        let Artist { id, name, .. } = self;
-        ArtistSummary { id, name, photo }
+impl From<Artist> for ArtistSummary {
+    fn from(artist: Artist) -> Self {
+        let photo = artist.best_image_for_width(200).map(|i| &i.url).cloned();
+        let Artist { id, name, .. } = artist;
+        Self { id, name, photo }
     }
 }
 
-impl Into<Vec<SongDescription>> for Page<PlaylistTrack> {
-    fn into(self) -> Vec<SongDescription> {
-        let items = self
+impl From<Page<PlaylistTrack>> for Vec<SongDescription> {
+    fn from(page: Page<PlaylistTrack>) -> Self {
+        let items = page
             .into_iter()
             .filter_map(|PlaylistTrack { is_local, track }| track.get().filter(|_| !is_local))
             .collect::<Vec<TrackItem>>();
@@ -244,15 +244,15 @@ impl Into<Vec<SongDescription>> for Page<PlaylistTrack> {
     }
 }
 
-impl Into<Vec<SongDescription>> for TopTracks {
-    fn into(self) -> Vec<SongDescription> {
-        Page::new(self.tracks).into()
+impl From<TopTracks> for Vec<SongDescription> {
+    fn from(top_tracks: TopTracks) -> Self {
+        Page::new(top_tracks.tracks).into()
     }
 }
 
-impl Into<Vec<SongDescription>> for Page<TrackItem> {
-    fn into(self) -> Vec<SongDescription> {
-        self.into_iter()
+impl From<Page<TrackItem>> for Vec<SongDescription> {
+    fn from(page: Page<TrackItem>) -> Self {
+        page.into_iter()
             .map(
                 |TrackItem {
                      album,
@@ -297,13 +297,14 @@ impl Into<Vec<SongDescription>> for Page<TrackItem> {
     }
 }
 
-impl Into<Vec<SongDescription>> for Album {
-    fn into(self) -> Vec<SongDescription> {
-        let art = self.best_image_for_width(200).map(|i| &i.url).cloned();
-        let Album { id, name, .. } = self;
+impl From<Album> for Vec<SongDescription> {
+    fn from(album: Album) -> Self {
+        let art = album.best_image_for_width(200).map(|i| &i.url).cloned();
+        let Album { id, name, .. } = album;
         let album_ref = AlbumRef { id, name };
 
-        self.tracks
+        album
+            .tracks
             .unwrap_or_default()
             .into_iter()
             .map(|item| {
@@ -330,9 +331,9 @@ impl Into<Vec<SongDescription>> for Album {
     }
 }
 
-impl Into<AlbumDescription> for Album {
-    fn into(self) -> AlbumDescription {
-        let artists = self
+impl From<Album> for AlbumDescription {
+    fn from(album: Album) -> Self {
+        let artists = album
             .artists
             .iter()
             .map(|a| ArtistRef {
@@ -340,12 +341,12 @@ impl Into<AlbumDescription> for Album {
                 name: a.name.clone(),
             })
             .collect::<Vec<ArtistRef>>();
-        let songs: Vec<SongDescription> = self.clone().into();
-        let art = self.best_image_for_width(200).map(|i| i.url.clone());
+        let songs: Vec<SongDescription> = album.clone().into();
+        let art = album.best_image_for_width(200).map(|i| i.url.clone());
 
-        AlbumDescription {
-            id: self.id,
-            title: self.name,
+        Self {
+            id: album.id,
+            title: album.name,
             artists,
             art,
             songs,

--- a/src/app/state/browser_state.rs
+++ b/src/app/state/browser_state.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use crate::app::models::*;
 use crate::app::state::AppAction;
-use std::convert::Into;
 use std::iter::Iterator;
 
 #[derive(Clone, Debug)]
@@ -29,9 +28,9 @@ pub enum BrowserAction {
     AppendUserPlaylists(Vec<PlaylistDescription>),
 }
 
-impl Into<AppAction> for BrowserAction {
-    fn into(self) -> AppAction {
-        AppAction::BrowserAction(self)
+impl From<BrowserAction> for AppAction {
+    fn from(browser_action: BrowserAction) -> Self {
+        Self::BrowserAction(browser_action)
     }
 }
 

--- a/src/app/state/login_state.rs
+++ b/src/app/state/login_state.rs
@@ -15,9 +15,9 @@ pub enum LoginAction {
     Logout,
 }
 
-impl Into<AppAction> for LoginAction {
-    fn into(self) -> AppAction {
-        AppAction::LoginAction(self)
+impl From<LoginAction> for AppAction {
+    fn from(login_action: LoginAction) -> Self {
+        Self::LoginAction(login_action)
     }
 }
 
@@ -31,9 +31,9 @@ pub enum LoginEvent {
     LogoutCompleted,
 }
 
-impl Into<AppEvent> for LoginEvent {
-    fn into(self) -> AppEvent {
-        AppEvent::LoginEvent(self)
+impl From<LoginEvent> for AppEvent {
+    fn from(login_event: LoginEvent) -> Self {
+        Self::LoginEvent(login_event)
     }
 }
 

--- a/src/app/state/playback_state.rs
+++ b/src/app/state/playback_state.rs
@@ -381,9 +381,9 @@ pub enum PlaybackAction {
     Dequeue(String),
 }
 
-impl Into<AppAction> for PlaybackAction {
-    fn into(self) -> AppAction {
-        AppAction::PlaybackAction(self)
+impl From<PlaybackAction> for AppAction {
+    fn from(playback_action: PlaybackAction) -> Self {
+        Self::PlaybackAction(playback_action)
     }
 }
 
@@ -398,9 +398,9 @@ pub enum PlaybackEvent {
     PlaybackStopped,
 }
 
-impl Into<AppEvent> for PlaybackEvent {
-    fn into(self) -> AppEvent {
-        AppEvent::PlaybackEvent(self)
+impl From<PlaybackEvent> for AppEvent {
+    fn from(playback_event: PlaybackEvent) -> Self {
+        Self::PlaybackEvent(playback_event)
     }
 }
 

--- a/src/app/state/selection_state.rs
+++ b/src/app/state/selection_state.rs
@@ -8,9 +8,9 @@ pub enum SelectionAction {
     Clear,
 }
 
-impl Into<AppAction> for SelectionAction {
-    fn into(self) -> AppAction {
-        AppAction::SelectionAction(self)
+impl From<SelectionAction> for AppAction {
+    fn from(selection_action: SelectionAction) -> Self {
+        Self::SelectionAction(selection_action)
     }
 }
 
@@ -20,9 +20,9 @@ pub enum SelectionEvent {
     SelectionChanged,
 }
 
-impl Into<AppEvent> for SelectionEvent {
-    fn into(self) -> AppEvent {
-        AppEvent::SelectionEvent(self)
+impl From<SelectionEvent> for AppEvent {
+    fn from(selection_event: SelectionEvent) -> Self {
+        Self::SelectionEvent(selection_event)
     }
 }
 


### PR DESCRIPTION
Hi,

First of all, thank you for this awesome app :)

This PR replaces the `Into` impls with `From` impls to fix clippy warnings as described in the issue #202.