### PR TITLE
Fix some clippy warnings

### DIFF
--- a/src/api/api_models.rs
+++ b/src/api/api_models.rs
@@ -380,8 +380,8 @@ impl Playlist {
             art,
             songs: tracks.into(),
             last_batch: Batch {
-                batch_size,
                 offset,
+                batch_size,
                 total,
             },
             owner: UserRef {

--- a/src/app/components/selection/selection_tools.rs
+++ b/src/app/components/selection/selection_tools.rs
@@ -70,7 +70,7 @@ pub trait SelectionToolsModel {
         let action = if all_selected {
             SelectionAction::Deselect(songs.iter().map(|s| &s.id).cloned().collect())
         } else {
-            SelectionAction::Select(songs.iter().cloned().collect())
+            SelectionAction::Select(songs.to_vec())
         };
         self.dispatcher().dispatch(action.into());
     }

--- a/src/app/components/user_details/user_details.rs
+++ b/src/app/components/user_details/user_details.rs
@@ -62,7 +62,7 @@ impl UserDetails {
             );
         }
 
-        Self { widget, model }
+        Self { model, widget }
     }
 
     fn update_details(&self) {

--- a/src/app/list_store.rs
+++ b/src/app/list_store.rs
@@ -73,7 +73,7 @@ where
             .unwrap()
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = GType> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = GType> + '_ {
         let store = &self.store;
         let count = store.get_n_items();
         (0..count).into_iter().map(move |i| self.get(i))

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -51,8 +51,8 @@ impl App {
         Self {
             settings,
             builder,
-            model,
             components,
+            model,
             sender,
             worker,
         }

--- a/src/app/state/playback_state.rs
+++ b/src/app/state/playback_state.rs
@@ -172,9 +172,9 @@ impl PlaybackState {
             self.current_song_id().cloned().into_iter().collect();
         to_shuffle.shuffle(&mut self.rng);
         final_list.append(&mut to_shuffle.into());
-        self.position
-            .as_mut()
-            .map(|p| p.update(0, final_list.len()));
+        if let Some(p) = self.position.as_mut() {
+            p.update(0, final_list.len())
+        }
         self.running_order_shuffled = Some(final_list);
     }
 

--- a/src/app/state/playback_state.rs
+++ b/src/app/state/playback_state.rs
@@ -117,7 +117,7 @@ impl PlaybackState {
             .unwrap_or(&mut self.running_order)
     }
 
-    pub fn songs<'s>(&'s self) -> impl Iterator<Item = &'s SongDescription> + 's {
+    pub fn songs(&self) -> impl Iterator<Item = &'_ SongDescription> + '_ {
         let indexed = &self.indexed_songs;
         let Position { start, count, .. } = self.position.unwrap_or_default();
         self.running_order()

--- a/src/app/state/playback_state.rs
+++ b/src/app/state/playback_state.rs
@@ -1,8 +1,5 @@
 use rand::{rngs::SmallRng, seq::SliceRandom, RngCore, SeedableRng};
-use std::{
-    collections::{HashMap, VecDeque},
-    convert::identity,
-};
+use std::collections::{HashMap, VecDeque};
 
 use crate::app::models::{Batch, SongBatch, SongDescription};
 use crate::app::state::{AppAction, AppEvent, UpdatableState};
@@ -405,7 +402,7 @@ impl From<PlaybackEvent> for AppEvent {
 }
 
 fn make_events(opt_events: Vec<Option<PlaybackEvent>>) -> Vec<PlaybackEvent> {
-    opt_events.into_iter().filter_map(identity).collect()
+    opt_events.into_iter().flatten().collect()
 }
 
 impl UpdatableState for PlaybackState {

--- a/src/app/state/screen_states.rs
+++ b/src/app/state/screen_states.rs
@@ -95,7 +95,7 @@ impl PlaylistDetailsState {
     pub fn new(id: String) -> Self {
         Self {
             id: id.clone(),
-            name: ScreenName::PlaylistDetails(id.clone()),
+            name: ScreenName::PlaylistDetails(id),
             playlist: None,
         }
     }

--- a/src/dbus/mpris.rs
+++ b/src/dbus/mpris.rs
@@ -146,7 +146,7 @@ impl SpotMprisPlayer {
     }
 
     pub fn seek(&self, Offset: i64) -> Result<()> {
-        if !self.state.current_track().is_some() {
+        if self.state.current_track().is_none() {
             return Ok(());
         }
 
@@ -174,7 +174,7 @@ impl SpotMprisPlayer {
     }
 
     pub fn set_position(&self, TrackId: ObjectPath, Position: i64) -> Result<()> {
-        if !self.state.current_track().is_some() {
+        if self.state.current_track().is_none() {
             return Ok(());
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ fn register_actions(app: &gtk::Application, sender: UnboundedSender<AppAction>) 
     app.add_action(&make_action(
         "nav_pop",
         AppAction::BrowserAction(BrowserAction::NavigationPop),
-        sender.clone(),
+        sender,
     ));
     app.set_accels_for_action("app.nav_pop", &["<Alt>Left"]);
 }

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -163,7 +163,7 @@ impl SpotifyPlayer {
             AudioBackend::Alsa(device) => {
                 println!("using alsa ({})", &device);
                 let backend = audio_backend::find(Some("alsa".to_string())).unwrap();
-                backend(Some(device.to_string()), AudioFormat::default())
+                backend(Some(device), AudioFormat::default())
             }
         })
     }

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -150,8 +150,10 @@ impl SpotifyPlayer {
     fn create_player(&self, session: Session) -> (Player, PlayerEventChannel) {
         let backend = self.settings.backend.clone();
 
-        let mut player_config = PlayerConfig::default();
-        player_config.bitrate = self.settings.bitrate;
+        let player_config = PlayerConfig {
+            bitrate: self.settings.bitrate,
+            ..Default::default()
+        };
         println!("bitrate: {:?}", &player_config.bitrate);
 
         Player::new(player_config, session, None, move || match backend {


### PR DESCRIPTION
The only remaining warnings now are [from_over_into](https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into) warnings produced by the `glib_wrapper` macro (which probably would have to be fixed upstream) and [module_inception](https://rust-lang.github.io/rust-clippy/master/index.html#module_inception) warnings. I didn't fix the "module_inception" warnings because it seems like you added the submodules on purpose and I think the warning is mostly there to warn beginners to not use `mod foo { ... }` inside foo.rs.

I think it might also be worth to consider adding clippy to the CI so future changes don't introduce new warnings.