### PR TITLE
Add DesktopEntry to MPRIS interface

### DIFF
--- a/src/dbus/mpris.rs
+++ b/src/dbus/mpris.rs
@@ -63,6 +63,11 @@ impl SpotMpris {
     fn supported_uri_schemes(&self) -> Vec<String> {
         vec![]
     }
+
+    #[dbus_interface(property)]
+    fn desktop_entry(&self) -> &'static str {
+        "dev.alextren.Spot"
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Implement https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:DesktopEntry

This allows, amongst other things, the Plasma task manager to map the window to the MPRIS player and display player controls in the panel item.