### PR TITLE
implement mpris Raise properly

### DIFF
--- a/src/app/components/window/mod.rs
+++ b/src/app/components/window/mod.rs
@@ -126,7 +126,7 @@ impl MainWindow {
     }
 
     fn raise(&self) {
-        self.window.show();
+        self.window.present();
     }
 }
 


### PR DESCRIPTION
As mentioned in #82, clicking the MPRIS-bubble in the notification center doesn't raise "Spot" in every case. 

What I did, is similar to what [Lollypop does](https://gitlab.gnome.org/World/lollypop/-/blob/15e7dc899502c5ed1f8e50e8c2c9224a3236f8e2/lollypop/mpris.py#L196-197), with the difference that instead of just calling `get_current_event_time()` there, we just let [gtk handle that](https://gitlab.gnome.org/GNOME/gtk/-/blob/77829cf3edf50b30ffb07b35bed9adcd0ecec3d3/gtk/gtkwindow.c#L5252-5266).

Calling `org.mpris.MediaPlayer2.Raise` method now causes the window to show itself if it was hidden before and fire a `"Spot" is ready` notification. 

A sidenote: In GNOME Shell, clicking the MPRIS-bubble doesn't necessarily call `Raise` (see [here](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/733a5e1acb004a3bd03f8e90182bd7129b105670/js/ui/mpris.js#L148-161)), so the actual behaviour might vary. However, it should work in any case now.

I'll be happy to adapt any changes or try some other things if necessary, just tell me!