### PR TITLE
add compact album view

### DIFF
--- a/src/app/components/album/album.rs
+++ b/src/app/components/album/album.rs
@@ -19,7 +19,7 @@ struct AlbumWidget {
 impl AlbumWidget {
     pub fn new() -> Self {
         screen_add_css_provider(resource!("/components/album.css"));
-        Self::from_resource(resource!("/components/album.ui")).unwrap()
+        Self::from_resource(resource!("/components/album_compact.ui")).unwrap()
     }
 }
 
@@ -38,7 +38,7 @@ impl Album {
             worker.send_local_task(async move {
                 if let (Some(image), Some(revealer)) = (image.upgrade(), revealer.upgrade()) {
                     let loader = ImageLoader::new();
-                    let result = loader.load_remote(&url, "jpg", 200, 200).await;
+                    let result = loader.load_remote(&url, "jpg", 75, 75).await;
                     image.set_from_pixbuf(result.as_ref());
                     revealer.set_reveal_child(true);
                 }

--- a/src/app/components/album/album_compact.ui
+++ b/src/app/components/album/album_compact.ui
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <!-- interface-css-provider-path album.css -->
+  <object class="GtkBox" id="root">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="halign">start</property>
+    <property name="valign">start</property>
+    <property name="margin-start">8</property>
+    <property name="margin-end">8</property>
+    <property name="margin-top">8</property>
+    <property name="margin-bottom">8</property>
+    <property name="spacing">8</property>
+    <property name="homogeneous">False</property>
+    <property name="baseline-position">top</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">center</property>
+        <child>
+          <object class="GtkRevealer" id="revealer">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="transition-type">crossfade</property>
+            <child>
+              <object class="GtkButton" id="cover_btn">
+                <property name="width-request">75</property>
+                <property name="height-request">75</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="relief">none</property>
+                <child>
+                  <object class="GtkImage" id="cover_image">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="icon-name">media-playback-start-symbolic</property>
+                  </object>
+                </child>
+                <style>
+                  <class name="album__cover"/>
+                </style>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">center</property>
+        <property name="hexpand">True</property>
+        <property name="vexpand">False</property>
+        <property name="orientation">vertical</property>
+        <property name="baseline-position">top</property>
+        <child>
+          <object class="GtkLabel" id="artist_label">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">start</property>
+            <property name="hexpand">True</property>
+            <property name="label">Pillars of ivory</property>
+            <property name="ellipsize">end</property>
+            <property name="single-line-mode">True</property>
+            <property name="max-width-chars">50</property>
+            <style>
+              <class name="album__artist"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="album_label">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">start</property>
+            <property name="hexpand">True</property>
+            <property name="label">Dedicated to the</property>
+            <property name="ellipsize">end</property>
+            <property name="single-line-mode">True</property>
+            <property name="max-width-chars">50</property>
+            <style>
+              <class name="album__title"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <style>
+      <class name="album__mobile"/>
+    </style>
+  </object>
+</interface>


### PR DESCRIPTION
In issue https://github.com/xou816/spot/issues/180 I raised the idea that the album layout should change when spot is on a mobile device to make better use of the screen real estate. This also applies to https://github.com/xou816/spot/issues/162

I wanted to give this issue a shot, but unfortunately as a back end focused engineer, I don't have the skills, or time to acquire the skills, to complete this.

I figured I'd push up the layout changes that I made so that someone else could use them as a starting place.

### Changes
- Adds album_compact.ui
- Changes in album.rs to make the size of the album art work better on mobile. (These values are hard-coded and should be changed based off of the width of the window)

If anyone does pick this up, I'd love to be tagged in your PR so I can hopefully learn a bit more and perhaps make more substantial contributions in the future. Thanks!