### PR TITLE
Seek bar improvments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See [this comment](https://github.com/xou816/spot/issues/92#issuecomment-8018525
 Spot can also be configured via `gsettings` if you want to change the audio backend, the song bitrate, etc. [A GUI is planned but not available yet.](https://github.com/xou816/spot/issues/142)
 
 ### Seek bar warping
-It is possible to click on the seek bar to navigate to that position in a song. If you are having issues with this not working you may have [gtk-primary-button-warps-slide](https://docs.gtk.org/gtk3/property.Settings.gtk-primary-button-warps-slider.html) set to false.
+It is possible to click on the seek bar to navigate to that position in a song. If you are having issues with this not working you may have [gtk-primary-button-warps-slider](https://docs.gtk.org/gtk3/property.Settings.gtk-primary-button-warps-slider.html) set to false.
 In order to fix this issue set the value to true in your gtk configuration.
 
 ### Scrobbling

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ See [this comment](https://github.com/xou816/spot/issues/92#issuecomment-8018525
 
 Spot can also be configured via `gsettings` if you want to change the audio backend, the song bitrate, etc. [A GUI is planned but not available yet.](https://github.com/xou816/spot/issues/142)
 
+### Seek bar warping
+It is possible to click on the seek bar to navigate to that position in a song. If you are having issues with this not working you may have [gtk-primary-button-warps-slide](https://docs.gtk.org/gtk3/property.Settings.gtk-primary-button-warps-slider.html) set to false.
+In order to fix this issue set the value to true in your gtk configuration.
+
 ### Scrobbling
 
 Scrobbling is not supported directly by Spot. However, you can use a tool such a [rescrobbled](https://github.com/InputUsername/rescrobbled) ([see #85](https://github.com/xou816/spot/issues/85)).

--- a/src/app/components/playback/playback_control.rs
+++ b/src/app/components/playback/playback_control.rs
@@ -121,11 +121,13 @@ impl PlaybackControl {
         widget.seek_bar.connect_change_value(
             clone!(@weak model, @weak track_position => @default-return signal::Inhibit(false), move |_, scroll, mut requested| {
                 match scroll {
-                    gtk::ScrollType::StepForward => {
+                    gtk::ScrollType::StepForward | gtk::ScrollType::PageForward => {
                         let duration = model.current_song_duration().unwrap_or(0.0);
                         requested = min_by(requested + STEP, duration, |a, b| a.partial_cmp(b).unwrap())
                     },
-                    gtk::ScrollType::StepBackward => requested = max_by(requested - STEP, 0.0, |a, b| a.partial_cmp(b).unwrap()),
+                    gtk::ScrollType::StepBackward | gtk::ScrollType::PageBackward => {
+                        requested = max_by(requested - STEP, 0.0, |a, b| a.partial_cmp(b).unwrap())
+                    },
                     _ => (),
                 }
                 track_position.set_text(&format_duration(requested));

--- a/src/app/components/playback/playback_control.rs
+++ b/src/app/components/playback/playback_control.rs
@@ -125,13 +125,12 @@ impl PlaybackControl {
 
         widget.seek_bar.connect_button_press_event(
             clone!(@weak model => @default-return signal::Inhibit(false), move|scale, event| {
-                let mut x = event.position().0;
+                let (mut x, y) = event.position();
                 let offset = scale.layout_offsets().0 as f64;
+                println!("y: {}", event.position().1);
                 if offset <= x { x-= offset; } // Just in case future has some offset
                 let width = scale.range_rect().width as f64;
-                // TODO figure out why sometimes clicking doesnt change song seconds
-                // Clicking slightly under seek changes the value but doesnt actually seek
-                if x >= 0.0 && width > 0.0 {
+                if y >= 0.0 && y <= 20.0 && x >= 0.0 && width > 0.0 {
                     scale.set_value(model.current_song_duration().unwrap_or(0.0) * (x / width));
                 }
                 signal::Inhibit(false)

--- a/src/app/components/playback/playback_control.rs
+++ b/src/app/components/playback/playback_control.rs
@@ -144,22 +144,6 @@ impl PlaybackControl {
             }),
         );
 
-        widget.seek_bar.connect_button_press_event(
-            clone!(@weak model => @default-return signal::Inhibit(false), move|seek_bar, event| {
-                let (x, y) = event.position();
-                let width = seek_bar.range_rect().width as f64;
-                if (3.0..=20.0).contains(&y) && width >= 16.0 && (9.0..=width - 9.0).contains(&x) {
-                    let x = if x > 16.0 { x - 16.0 } else { 0.0 };
-                    let amount = model.current_song_duration().unwrap_or(0.0) * (x / (width - 16.0));
-                    let amount = if amount < 3000.0 { amount } else { amount + 3000.0 };
-                    seek_bar.set_value(amount);
-                    signal::Inhibit(false)
-                } else {
-                    signal::Inhibit(true) // Ignore
-                }
-            }),
-        );
-
         widget.seek_bar.connect_scroll_event(move |_, _| {
             /*
             Scrolling doesnt work well. Only shows direction if the slider is clicked

--- a/src/app/components/playback/playback_control.rs
+++ b/src/app/components/playback/playback_control.rs
@@ -125,10 +125,7 @@ impl PlaybackControl {
 
         widget.seek_bar.connect_button_press_event(
             clone!(@weak model => @default-return signal::Inhibit(false), move|scale, event| {
-                let (mut x, y) = event.position();
-                let offset = scale.layout_offsets().0 as f64;
-                println!("y: {}", event.position().1);
-                if offset <= x { x-= offset; } // Just in case future has some offset
+                let (x, y) = event.position();
                 let width = scale.range_rect().width as f64;
                 if y >= 0.0 && y <= 20.0 && x >= 0.0 && width > 0.0 {
                     scale.set_value(model.current_song_duration().unwrap_or(0.0) * (x / width));

--- a/src/app/components/playback/playback_control.rs
+++ b/src/app/components/playback/playback_control.rs
@@ -148,7 +148,7 @@ impl PlaybackControl {
             clone!(@weak model => @default-return signal::Inhibit(false), move|seek_bar, event| {
                 let (x, y) = event.position();
                 let width = seek_bar.range_rect().width as f64;
-                if y >= 3.0 && y <= 20.0 && x >= 9.0 && width >= 16.0 && x <= width - 9.0 {
+                if (3.0..=20.0).contains(&y) && width >= 16.0 && (9.0..=width - 9.0).contains(&x) {
                     let x = if x > 16.0 { x - 16.0 } else { 0.0 };
                     let amount = model.current_song_duration().unwrap_or(0.0) * (x / (width - 16.0));
                     let amount = if amount < 3000.0 { amount } else { amount + 3000.0 };

--- a/src/app/components/playback/playback_control.rs
+++ b/src/app/components/playback/playback_control.rs
@@ -98,8 +98,8 @@ impl PlaybackControl {
         let model = Rc::new(model);
         let debouncer = Debouncer::new();
         let debouncer_clone = debouncer.clone();
-
         let track_position = &widget.track_position;
+
         widget.seek_bar.connect_change_value(
             clone!(@weak model, @weak track_position => @default-return signal::Inhibit(false), move |_, scroll, mut requested| {
                 match scroll {
@@ -125,7 +125,9 @@ impl PlaybackControl {
 
         widget.seek_bar.connect_button_press_event(
             clone!(@weak model => @default-return signal::Inhibit(false), move|scale, event| {
-                let x = event.position().0;
+                let mut x = event.position().0;
+                let offset = scale.layout_offsets().0 as f64;
+                if offset <= x { x-= offset; } // Just in case future has some offset
                 let width = scale.range_rect().width as f64;
                 // TODO figure out why sometimes clicking doesnt change song seconds
                 // Clicking slightly under seek changes the value but doesnt actually seek

--- a/src/app/components/playback/playback_control.rs
+++ b/src/app/components/playback/playback_control.rs
@@ -160,15 +160,13 @@ impl PlaybackControl {
             }),
         );
 
-        widget.seek_bar.connect_scroll_event(
-            move|_, _| {
-                /*
-                Scrolling doesnt work well. Only shows direction if the slider is clicked
-                So ignore this event
-                */
-                signal::Inhibit(true)
-            }
-        );
+        widget.seek_bar.connect_scroll_event(move |_, _| {
+            /*
+            Scrolling doesnt work well. Only shows direction if the slider is clicked
+            So ignore this event
+            */
+            signal::Inhibit(true)
+        });
 
         widget
             .play_button

--- a/src/app/components/playback/playback_control.rs
+++ b/src/app/components/playback/playback_control.rs
@@ -128,19 +128,29 @@ impl PlaybackControl {
         );
 
         widget.seek_bar.connect_button_press_event(
-            clone!(@weak model, @weak track_position => @default-return signal::Inhibit(false), move|scale, event| {
+            clone!(@weak model => @default-return signal::Inhibit(false), move|seek_bar, event| {
                 let (x, y) = event.position();
-                let width = scale.range_rect().width as f64;
+                let width = seek_bar.range_rect().width as f64;
                 if y >= 3.0 && y <= 20.0 && x >= 9.0 && width >= 16.0 && x <= width - 9.0 {
                     let x = if x > 16.0 { x - 16.0 } else { 0.0 };
                     let amount = model.current_song_duration().unwrap_or(0.0) * (x / (width - 16.0));
                     let amount = if amount < 3000.0 { amount } else { amount + 3000.0 };
-                    scale.set_value(amount);
+                    seek_bar.set_value(amount);
                     signal::Inhibit(false)
                 } else {
                     signal::Inhibit(true) // Ignore
                 }
             }),
+        );
+
+        widget.seek_bar.connect_scroll_event(
+            move|_, _| {
+                /*
+                Scrolling doesnt work well. Only shows direction if the slider is clicked
+                So ignore this event
+                */
+                signal::Inhibit(true)
+            }
         );
 
         widget

--- a/src/app/components/playback/playback_control.rs
+++ b/src/app/components/playback/playback_control.rs
@@ -101,11 +101,19 @@ impl PlaybackControl {
 
         let track_position = &widget.track_position;
         widget.seek_bar.connect_change_value(
-            clone!(@weak model, @weak track_position => @default-return signal::Inhibit(false), move |_, _, requested| {
+            clone!(@weak model, @weak track_position => @default-return signal::Inhibit(false), move |a, scroll, requested| {
+                PlaybackControl::seek_bar_control(a, scroll, requested); // TODO use this to implement scolling of seek_bar
                 track_position.set_text(&format_duration(requested));
                 debouncer_clone.debounce(200, move || {
                     model.seek_to(requested as u32);
                 });
+                signal::Inhibit(false)
+            }),
+        );
+        widget.seek_bar.connect_button_press_event(
+            clone!(@weak model, @weak track_position => @default-return signal::Inhibit(false), move |a, event| {
+                // TODO use this to specify the exact position to set seek (find ratio and use that based of x value)
+                println!("{:#?}", event.position());
                 signal::Inhibit(false)
             }),
         );
@@ -121,7 +129,7 @@ impl PlaybackControl {
         }));
 
         widget.prev.connect_clicked(clone!(@weak model => move |_| {
-            model.play_prev_song()
+            model.play_prev_song();
         }));
 
         Self {
@@ -130,6 +138,10 @@ impl PlaybackControl {
             _debouncer: debouncer,
             clock: Clock::new(),
         }
+    }
+
+    pub fn seek_bar_control(scale: &gtk::Scale, scroll: gtk::ScrollType, value: f64) {
+        // TODO use this for something
     }
 
     fn set_playing(&self, is_playing: bool) {

--- a/src/app/components/selection/selection_heading.rs
+++ b/src/app/components/selection/selection_heading.rs
@@ -31,7 +31,7 @@ impl SelectionHeadingModel {
     fn should_change_context(&self) -> bool {
         let state = self.app_model.get_state();
         state.selection.context != SelectionContext::Global
-            && state.recommanded_context() != state.selection.context
+            && state.recommended_context() != state.selection.context
     }
 }
 

--- a/src/app/state/app_state.rs
+++ b/src/app/state/app_state.rs
@@ -77,7 +77,7 @@ impl AppState {
         }
     }
 
-    pub fn recommanded_context(&self) -> SelectionContext {
+    pub fn recommended_context(&self) -> SelectionContext {
         match self.browser.current_screen() {
             ScreenName::PlaylistDetails(_) => SelectionContext::Playlist,
             // TODO: this does not necessarily mean we're actually viewing the playqueue :(
@@ -129,7 +129,7 @@ impl AppState {
             }
             AppAction::ChangeSelectionMode(active) => {
                 let context = if active {
-                    Some(self.recommanded_context())
+                    Some(self.recommended_context())
                 } else {
                     None
                 };

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-pub static PKGDATADIR: &str = "/home/alexandre/.local/share/spot";
+pub static PKGDATADIR: &str = "/home/totaldarkness/.local/share/spot";
 pub static VERSION: &str = "0.1.15-dev";
-pub static LOCALEDIR: &str = "/home/alexandre/.local/share/locale";
+pub static LOCALEDIR: &str = "/home/totaldarkness/.local/share/locale";
 pub static APPID: &str = "dev.alextren.Spot.Devel";

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,11 +80,6 @@ fn startup(settings: &settings::SpotSettings) {
         .unwrap()
         .set_gtk_application_prefer_dark_theme(settings.prefers_dark_theme);
 
-    //Make the slider move on click
-    gtk::Settings::default()
-        .unwrap()
-        .set_gtk_primary_button_warps_slider(true);
-
     let provider = gtk::CssProvider::new();
     provider.load_from_resource("/dev/alextren/Spot/app.css");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,9 @@ fn startup(settings: &settings::SpotSettings) {
         .set_gtk_application_prefer_dark_theme(settings.prefers_dark_theme);
 
     //Make the slider move on click
-    gtk::Settings::default().unwrap().set_gtk_primary_button_warps_slider(true);
+    gtk::Settings::default()
+        .unwrap()
+        .set_gtk_primary_button_warps_slider(true);
 
     let provider = gtk::CssProvider::new();
     provider.load_from_resource("/dev/alextren/Spot/app.css");

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,9 @@ fn startup(settings: &settings::SpotSettings) {
         .unwrap()
         .set_gtk_application_prefer_dark_theme(settings.prefers_dark_theme);
 
+    //Make the slider move on click
+    gtk::Settings::default().unwrap().set_gtk_primary_button_warps_slider(true);
+
     let provider = gtk::CssProvider::new();
     provider.load_from_resource("/dev/alextren/Spot/app.css");
 


### PR DESCRIPTION
This focuses on improving the functionality of the seek bar.
- Remove sending to same position for clicking, scrolling, and using arrow keys
- Add Fix for when gtk setting "gtk-primary-button-warps-slider" is false [*1]
- Add ability to use arrows keys to go forward or backwards by 5 seconds

Hopefully this helps to improve the seekbar. 

[*1] When the gtksetting is false the click to send it to that position will not work and will send the slider to around the same place it already was. Now all users should be able to be able to click the seekbar and have it work, regardless of there gtk settings
