### PR TITLE
Add --device=dri so GTK4 can access GPU

### DIFF
--- a/dev.alextren.Spot.develoment.json
+++ b/dev.alextren.Spot.develoment.json
@@ -13,6 +13,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
+        "--device=dri",
         "--talk-name=org.freedesktop.secrets",
         "--own-name=org.mpris.MediaPlayer2.Spot"
     ],


### PR DESCRIPTION
Without --device=dri, GTK4 falls back to Cairo based CPU rendering.