### PR TITLE
Adding Purism's custom FormFactor specification

### DIFF
--- a/data/dev.alextren.Spot.appdata.xml
+++ b/data/dev.alextren.Spot.appdata.xml
@@ -245,4 +245,8 @@
       </description>
     </release>
   </releases>
+  <custom>
+    <value key="Purism::form_factor">workstation</value>
+    <value key="Purism::form_factor">mobile</value>
+  </custom>
 </component>

--- a/data/dev.alextren.Spot.desktop
+++ b/data/dev.alextren.Spot.desktop
@@ -7,3 +7,4 @@ Terminal=false
 Type=Application
 Categories=GTK;GNOME;Music;AudioVideo;
 StartupNotify=true
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
This should improve discoverability of the app in PureOS store on the Librem 5 and help with Phosh on other (e.g. PinePhone) distributions.