### PR TITLE
Added spotify URI handler

### DIFF
--- a/data/dev.alextren.Spot.desktop
+++ b/data/dev.alextren.Spot.desktop
@@ -1,10 +1,11 @@
 [Desktop Entry]
 Version=1.0
 Name=Spot
-Exec=spot
+Exec=spot %u
 Icon=dev.alextren.Spot
 Terminal=false
 Type=Application
 Categories=GTK;GNOME;Music;AudioVideo;
+MimeType=x-scheme-handler/spotify;
 StartupNotify=true
 X-Purism-FormFactor=Workstation;Mobile;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ extern crate lazy_static;
 
 use futures::channel::mpsc::UnboundedSender;
 use gettextrs::*;
+use gio::ApplicationFlags;
 use gio::prelude::*;
 use gio::SimpleAction;
 use gtk::prelude::*;
@@ -29,7 +30,7 @@ fn main() {
 
     let settings = settings::SpotSettings::new_from_gsettings().unwrap_or_default();
     startup(&settings);
-    let gtk_app = gtk::Application::new(Some(config::APPID), Default::default());
+    let gtk_app = gtk::Application::new(Some(config::APPID), ApplicationFlags::HANDLES_OPEN);
     expose_widgets();
     let builder = gtk::Builder::from_resource("/dev/alextren/Spot/window.ui");
     let window: libadwaita::ApplicationWindow = builder.object("window").unwrap();
@@ -59,6 +60,58 @@ fn main() {
             window.set_application(Some(gtk_app));
             gtk_app.add_window(&window);
             sender.unbounded_send(AppAction::Start).unwrap();
+        }
+    });
+
+    gtk_app.connect_open(move |_, targets, _| {
+        // TODO: the activate signal isn't called when open is, but window and sender are already moved to the activate closure at this point
+        // There should only be one target because %u is used in desktop file
+        let target = &targets[0];
+        let uri = target.uri().to_string();
+        let mut parts = uri.split(':');
+        if parts.next().unwrap_or_default() != "spotify" {
+            return
+        }
+        let action = parts.next().unwrap_or_default();
+        // Might start with /// because of https://gitlab.gnome.org/GNOME/glib/-/issues/1886/
+        let action = action.strip_prefix("///").unwrap_or(action);
+        if action.is_empty() {
+            return
+        }
+        let data = parts.next().unwrap_or_default();
+        if data.is_empty() {
+            return
+        }
+        match action {
+            "artist" => {
+                todo!("Handle artist in URI")
+            },
+            "album" => {
+                todo!("Handle album in URI")
+            },
+            "track" => {
+                todo!("Handle track in URI")
+            },
+            "search" => {
+                todo!("Handle search in URI")
+            },
+            "user" => {
+                let user_action = parts.next().unwrap_or_default();
+                if user_action.is_empty() {
+                    return
+                }
+                let user_data = parts.next().unwrap_or_default();        
+                if user_data.is_empty() {
+                    return
+                }
+                match user_action {
+                    "playlist" => {
+                        todo!("Handle playlist in URI")
+                    }
+                    _ => return,
+                }
+            },
+            _ => return,
         }
     });
 


### PR DESCRIPTION
This is still very WIP, I managed to register the `spotify` URI.
I ran into a problem with ownership that I'm not sure how to tackle, when the `open` signal is called the `activate` signal isn't, so if in the `open` closure we need to open/focus the window. The problem is the closure in `Application::connect_activate` and closure in `Application::connect_open` both need to take ownership of `window` and `sender` because they have static lifetimes and the compiler thinks they might be able to outlive `main` (even though they can't).