### PR TITLE
232 show album name in playlists and queue

### DIFF
--- a/src/app/components/artist_details/artist_details.rs
+++ b/src/app/components/artist_details/artist_details.rs
@@ -144,6 +144,7 @@ impl ArtistDetails {
             widget.top_tracks_widget().clone(),
             Rc::clone(&model),
             worker,
+            true,
         ));
 
         Self {

--- a/src/app/components/artist_details/artist_details.rs
+++ b/src/app/components/artist_details/artist_details.rs
@@ -132,7 +132,7 @@ impl ArtistDetails {
 
         if let Some(store) = model.get_list_store() {
             widget.bind_artist_releases(
-                worker,
+                worker.clone(),
                 &*store,
                 clone!(@weak model => move |id| {
                     model.open_album(id);
@@ -143,6 +143,7 @@ impl ArtistDetails {
         let playlist = Box::new(Playlist::new(
             widget.top_tracks_widget().clone(),
             Rc::clone(&model),
+            worker,
         ));
 
         Self {

--- a/src/app/components/details/details.rs
+++ b/src/app/components/details/details.rs
@@ -185,6 +185,7 @@ impl Details {
         let playlist = Box::new(Playlist::new(
             widget.album_tracks_widget().clone(),
             model.clone(),
+            worker.clone(),
         ));
 
         let modal = ReleaseDetailsWindow::new();

--- a/src/app/components/details/details.rs
+++ b/src/app/components/details/details.rs
@@ -186,6 +186,7 @@ impl Details {
             widget.album_tracks_widget().clone(),
             model.clone(),
             worker.clone(),
+            false,
         ));
 
         let modal = ReleaseDetailsWindow::new();

--- a/src/app/components/navigation/factory.rs
+++ b/src/app/components/navigation/factory.rs
@@ -38,7 +38,10 @@ impl ScreenFactory {
             Rc::clone(&self.app_model),
             self.dispatcher.box_clone(),
         ));
-        SelectionTools::new(NowPlaying::new(Rc::clone(&model)), model)
+        SelectionTools::new(
+            NowPlaying::new(Rc::clone(&model), self.worker.clone()),
+            model,
+        )
     }
 
     pub fn make_saved_tracks(&self) -> impl ListenerComponent {
@@ -46,7 +49,10 @@ impl ScreenFactory {
             Rc::clone(&self.app_model),
             self.dispatcher.box_clone(),
         ));
-        SelectionTools::new(SavedTracks::new(Rc::clone(&model)), model)
+        SelectionTools::new(
+            SavedTracks::new(Rc::clone(&model), self.worker.clone()),
+            model,
+        )
     }
 
     pub fn make_album_details(&self, id: String) -> impl ListenerComponent {

--- a/src/app/components/now_playing/now_playing.rs
+++ b/src/app/components/now_playing/now_playing.rs
@@ -4,7 +4,7 @@ use gtk::CompositeTemplate;
 use std::rc::Rc;
 
 use crate::app::components::{display_add_css_provider, Component, EventListener, Playlist};
-use crate::app::{state::PlaybackEvent, AppEvent};
+use crate::app::{state::PlaybackEvent, AppEvent, Worker};
 
 use super::NowPlayingModel;
 
@@ -79,14 +79,14 @@ pub struct NowPlaying {
 }
 
 impl NowPlaying {
-    pub fn new(model: Rc<NowPlayingModel>) -> Self {
+    pub fn new(model: Rc<NowPlayingModel>, worker: Worker) -> Self {
         let widget = NowPlayingWidget::new();
 
         widget.connect_bottom_edge(clone!(@weak model => move || {
             model.load_more();
         }));
 
-        let playlist = Playlist::new(widget.song_list_widget().clone(), model.clone());
+        let playlist = Playlist::new(widget.song_list_widget().clone(), model.clone(), worker);
 
         Self {
             widget,

--- a/src/app/components/now_playing/now_playing.rs
+++ b/src/app/components/now_playing/now_playing.rs
@@ -86,7 +86,12 @@ impl NowPlaying {
             model.load_more();
         }));
 
-        let playlist = Playlist::new(widget.song_list_widget().clone(), model.clone(), worker);
+        let playlist = Playlist::new(
+            widget.song_list_widget().clone(),
+            model.clone(),
+            worker,
+            true,
+        );
 
         Self {
             widget,

--- a/src/app/components/playlist/playlist.rs
+++ b/src/app/components/playlist/playlist.rs
@@ -64,7 +64,12 @@ impl<Model> Playlist<Model>
 where
     Model: PlaylistModel + 'static,
 {
-    pub fn new(listview: gtk::ListView, model: Rc<Model>, worker: Worker) -> Self {
+    pub fn new(
+        listview: gtk::ListView,
+        model: Rc<Model>,
+        worker: Worker,
+        show_song_covers: bool,
+    ) -> Self {
         let list_model = ListStore::new();
         let selection_model = gtk::NoSelection::new(Some(list_model.unsafe_store()));
         let factory = gtk::SignalListItemFactory::new();
@@ -84,7 +89,7 @@ where
             song_model.set_state(Self::get_item_state(&*model, &song_model));
 
             let widget = item.child().unwrap().downcast::<SongWidget>().unwrap();
-            widget.bind(&song_model, worker.clone());
+            widget.bind(&song_model, worker.clone(), show_song_covers);
 
             let id = &song_model.get_id();
             widget.set_actions(model.actions_for(id).as_ref());

--- a/src/app/components/playlist/playlist.rs
+++ b/src/app/components/playlist/playlist.rs
@@ -8,7 +8,7 @@ use crate::app::components::{Component, EventListener, SongWidget};
 use crate::app::models::SongModel;
 use crate::app::{
     state::{PlaybackEvent, SelectionEvent, SelectionState},
-    AppEvent, ListDiff, ListStore,
+    AppEvent, ListDiff, ListStore, Worker,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -64,7 +64,7 @@ impl<Model> Playlist<Model>
 where
     Model: PlaylistModel + 'static,
 {
-    pub fn new(listview: gtk::ListView, model: Rc<Model>) -> Self {
+    pub fn new(listview: gtk::ListView, model: Rc<Model>, worker: Worker) -> Self {
         let list_model = ListStore::new();
         let selection_model = gtk::NoSelection::new(Some(list_model.unsafe_store()));
         let factory = gtk::SignalListItemFactory::new();
@@ -84,7 +84,7 @@ where
             song_model.set_state(Self::get_item_state(&*model, &song_model));
 
             let widget = item.child().unwrap().downcast::<SongWidget>().unwrap();
-            widget.bind(&song_model);
+            widget.bind(&song_model, worker.clone());
 
             let id = &song_model.get_id();
             widget.set_actions(model.actions_for(id).as_ref());

--- a/src/app/components/playlist/song.rs
+++ b/src/app/components/playlist/song.rs
@@ -1,6 +1,7 @@
 use crate::app::components::display_add_css_provider;
 use crate::app::models::SongModel;
 
+use crate::app::Worker;
 use gio::MenuModel;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
@@ -70,9 +71,9 @@ impl SongWidget {
         glib::Object::new(&[]).expect("Failed to create an instance of SongWidget")
     }
 
-    pub fn for_model(model: SongModel) -> Self {
+    pub fn for_model(model: SongModel, worker: Worker) -> Self {
         let _self = Self::new();
-        _self.bind(&model);
+        _self.bind(&model, worker);
         _self
     }
 
@@ -114,7 +115,7 @@ impl SongWidget {
         }
     }
 
-    pub fn bind(&self, model: &SongModel) {
+    pub fn bind(&self, model: &SongModel, worker: Worker) {
         let widget = imp::SongWidget::from_instance(self);
 
         model.bind_index(&*widget.song_index, "label");

--- a/src/app/components/playlist/song.rs
+++ b/src/app/components/playlist/song.rs
@@ -77,7 +77,7 @@ impl SongWidget {
 
     pub fn for_model(model: SongModel, worker: Worker) -> Self {
         let _self = Self::new();
-        _self.bind(&model, worker);
+        _self.bind(&model, worker, true);
         _self
     }
 
@@ -138,14 +138,17 @@ impl SongWidget {
         }
     }
 
-    pub fn bind(&self, model: &SongModel, worker: Worker) {
+    pub fn bind(&self, model: &SongModel, worker: Worker, show_cover: bool) {
         let widget = imp::SongWidget::from_instance(self);
 
-        model.bind_index(&*widget.song_index, "label");
         model.bind_title(&*widget.song_title, "label");
         model.bind_artist(&*widget.song_artist, "label");
         model.bind_duration(&*widget.song_length, "label");
-        self.bind_art(model, worker);
+        if show_cover {
+            self.bind_art(model, worker);
+        } else {
+            model.bind_index(&*widget.song_index, "label");
+        }
 
         self.set_playing(model.get_playing());
         model.connect_playing_local(clone!(@weak self as _self => move |song| {

--- a/src/app/components/playlist/song.ui
+++ b/src/app/components/playlist/song.ui
@@ -25,6 +25,14 @@
           </object>
         </child>
         <child type="overlay">
+          <object class="GtkImage" id="song_cover">
+            <property name="pixel-size">30</property>
+            <style>
+              <class name="song__cover"/>
+            </style>
+          </object>
+        </child>
+        <child type="overlay">
           <object class="GtkImage" id="song_icon">
             <property name="icon-name">media-playback-start-symbolic</property>
             <style>

--- a/src/app/components/playlist_details/playlist_details.rs
+++ b/src/app/components/playlist_details/playlist_details.rs
@@ -175,6 +175,7 @@ impl PlaylistDetails {
             widget.playlist_tracks_widget().clone(),
             model.clone(),
             worker.clone(),
+            true,
         ));
 
         widget.connect_header();

--- a/src/app/components/playlist_details/playlist_details.rs
+++ b/src/app/components/playlist_details/playlist_details.rs
@@ -174,6 +174,7 @@ impl PlaylistDetails {
         let playlist = Box::new(Playlist::new(
             widget.playlist_tracks_widget().clone(),
             model.clone(),
+            worker.clone(),
         ));
 
         widget.connect_header();

--- a/src/app/components/saved_tracks/saved_tracks.rs
+++ b/src/app/components/saved_tracks/saved_tracks.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use crate::app::components::{display_add_css_provider, Component, EventListener, Playlist};
 use crate::app::state::LoginEvent;
-use crate::app::AppEvent;
+use crate::app::{AppEvent, Worker};
 
 use super::SavedTracksModel;
 
@@ -80,14 +80,14 @@ pub struct SavedTracks {
 }
 
 impl SavedTracks {
-    pub fn new(model: Rc<SavedTracksModel>) -> Self {
+    pub fn new(model: Rc<SavedTracksModel>, worker: Worker) -> Self {
         let widget = SavedTracksWidget::new();
 
         widget.connect_bottom_edge(clone!(@weak model => move || {
             model.load_more();
         }));
 
-        let playlist = Playlist::new(widget.song_list_widget().clone(), model.clone());
+        let playlist = Playlist::new(widget.song_list_widget().clone(), model.clone(), worker);
 
         Self {
             widget,

--- a/src/app/components/saved_tracks/saved_tracks.rs
+++ b/src/app/components/saved_tracks/saved_tracks.rs
@@ -87,7 +87,12 @@ impl SavedTracks {
             model.load_more();
         }));
 
-        let playlist = Playlist::new(widget.song_list_widget().clone(), model.clone(), worker);
+        let playlist = Playlist::new(
+            widget.song_list_widget().clone(),
+            model.clone(),
+            worker,
+            true,
+        );
 
         Self {
             widget,

--- a/src/app/models/gtypes/song_model.rs
+++ b/src/app/models/gtypes/song_model.rs
@@ -10,15 +10,31 @@ glib::wrapper! {
 // Constructor for new instances. This simply calls glib::Object::new() with
 // initial values for our two properties and then returns the new instance
 impl SongModel {
-    pub fn new(id: &str, index: u32, title: &str, artist: &str, duration: &str) -> SongModel {
+    pub fn new(
+        id: &str,
+        index: u32,
+        title: &str,
+        artist: &str,
+        duration: &str,
+        art: &Option<String>,
+    ) -> SongModel {
         glib::Object::new::<SongModel>(&[
             ("index", &index),
             ("title", &title),
             ("artist", &artist),
             ("id", &id),
             ("duration", &duration),
+            ("art", &art),
         ])
         .expect("Failed to create")
+    }
+
+    pub fn cover_url(&self) -> Option<String> {
+        self.property("art")
+            .unwrap()
+            .get::<&str>()
+            .ok()
+            .map(|s| s.to_string())
     }
 
     pub fn set_playing(&self, is_playing: bool) {
@@ -128,6 +144,7 @@ mod imp {
         title: RefCell<Option<String>>,
         artist: RefCell<Option<String>>,
         duration: RefCell<Option<String>>,
+        art: RefCell<Option<String>>,
         playing: RefCell<bool>,
         selected: RefCell<bool>,
         bindings: RefCell<BindingsInner>,
@@ -176,6 +193,7 @@ mod imp {
                 title: RefCell::new(None),
                 artist: RefCell::new(None),
                 duration: RefCell::new(None),
+                art: RefCell::new(None),
                 playing: RefCell::new(false),
                 selected: RefCell::new(false),
                 bindings: RefCell::new(Default::default()),
@@ -185,7 +203,7 @@ mod imp {
 
     // Static array for defining the properties of the new type.
     lazy_static! {
-        static ref PROPERTIES: [glib::ParamSpec; 7] = [
+        static ref PROPERTIES: [glib::ParamSpec; 8] = [
             glib::ParamSpec::new_uint(
                 "index",
                 "Index",
@@ -219,6 +237,7 @@ mod imp {
                 false,
                 glib::ParamFlags::READWRITE,
             ),
+            glib::ParamSpec::new_string("art", "Art", "", None, glib::ParamFlags::READWRITE,),
         ];
     }
 
@@ -268,6 +287,12 @@ mod imp {
                         .expect("type conformity checked by `Object::set_property`");
                     self.duration.replace(dur);
                 }
+                "art" => {
+                    let art = value
+                        .get()
+                        .expect("type conformity checked by `Object::set_property`");
+                    self.art.replace(art);
+                }
                 "playing" => {
                     let playing = value
                         .get()
@@ -293,6 +318,7 @@ mod imp {
                 "artist" => self.artist.borrow().to_value(),
                 "id" => self.id.borrow().to_value(),
                 "duration" => self.duration.borrow().to_value(),
+                "art" => self.art.borrow().to_value(),
                 "playing" => self.playing.borrow().to_value(),
                 "selected" => self.selected.borrow().to_value(),
                 _ => unimplemented!(),

--- a/src/app/models/main.rs
+++ b/src/app/models/main.rs
@@ -42,6 +42,7 @@ impl From<&SongDescription> for SongModel {
             &song.title,
             &song.artists_name(),
             &format_duration(song.duration.into()),
+            &song.art,
         )
     }
 }


### PR DESCRIPTION
Addresses #232 

I inserted a column for the album name in the playlist view, as was described in the issue.

I'm not entirely happy with how the UI looks with it now. I think it would look best if we showed the album name beneath the artist, but I feel like that would be worse since it wastes so much vertical space.
I'm attaching a screenshot so we can discuss.
![image](https://user-images.githubusercontent.com/91668665/136058680-e3f271dd-3bae-47b1-b447-4eda8d039191.png)

Since I am not experienced with both Rust and GTK I'd be happy for any pointers as to what could be improved here, even though this is a small change.

Thanks for the awesome spotify client!