### PR TITLE
basic connect implementation

### DIFF
--- a/src/api/cached_client.rs
+++ b/src/api/cached_client.rs
@@ -95,6 +95,12 @@ pub trait SpotifyApiClient {
     ) -> BoxFuture<SpotifyResult<Vec<PlaylistDescription>>>;
 
     fn update_token(&self, token: String);
+
+    fn player_pause(&self) -> BoxFuture<SpotifyResult<()>>;
+    fn player_play(&self, uri: Option<String>) -> BoxFuture<SpotifyResult<()>>;
+    fn player_next(&self) -> BoxFuture<SpotifyResult<()>>;
+    fn player_seek(&self, pos: usize) -> BoxFuture<SpotifyResult<()>>;
+    fn add_to_queue(&self, uri: String) -> BoxFuture<SpotifyResult<()>>;
 }
 
 enum SpotCacheKey<'a> {
@@ -579,6 +585,45 @@ impl SpotifyApiClient for CachedSpotifyClient {
                 playlists: playlists?,
             };
             Ok(result)
+        })
+    }
+
+    fn player_pause(&self) -> BoxFuture<SpotifyResult<()>> {
+        Box::pin(async move {
+            self.client.player_pause().send_no_response().await?;
+            Ok(())
+        })
+    }
+
+    fn player_play(&self, uri: Option<String>) -> BoxFuture<SpotifyResult<()>> {
+        Box::pin(async move {
+            if let Some(uri) = uri {
+                self.client.player_play_uri(uri).send_no_response().await?;
+            } else {
+                self.client.player_play().send_no_response().await?;
+            }
+            Ok(())
+        })
+    }
+
+    fn player_next(&self) -> BoxFuture<SpotifyResult<()>> {
+        Box::pin(async move {
+            self.client.player_next().send_no_response().await?;
+            Ok(())
+        })
+    }
+
+    fn add_to_queue(&self, uri: String) -> BoxFuture<SpotifyResult<()>> {
+        Box::pin(async move {
+            self.client.add_to_queue(uri).send_no_response().await?;
+            Ok(())
+        })
+    }
+
+    fn player_seek(&self, pos: usize) -> BoxFuture<SpotifyResult<()>> {
+        Box::pin(async move {
+            self.client.player_seek(pos).send_no_response().await?;
+            Ok(())
         })
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -458,6 +458,67 @@ impl SpotifyClient {
             .method(Method::GET)
             .uri(format!("/v1/users/{}/playlists", id), Some(&query))
     }
+
+    pub(crate) fn get_player_devices(&self) -> SpotifyRequest<'_, (), ()> {
+        self.request()
+            .method(Method::GET)
+            .uri("/v1/me/player/devices".to_string(), None)
+    }
+
+    pub(crate) fn get_player_playing(&self) -> SpotifyRequest<'_, (), ()> {
+        self.request()
+            .method(Method::GET)
+            .uri("/v1/me/player/currently-playing".to_string(), None)
+    }
+
+    pub(crate) fn player_play(&self) -> SpotifyRequest<'_, (), ()> {
+        self.request()
+            .method(Method::PUT)
+            .uri("/v1/me/player/play".to_string(), None)
+    }
+
+    pub(crate) fn player_play_uri(&self, uri: String) -> SpotifyRequest<'_, Vec<u8>, ()> {
+        self.request()
+            .method(Method::PUT)
+            .uri("/v1/me/player/play".to_string(), None)
+            .json_body(Uris { uris: vec![uri] })
+    }
+
+    pub(crate) fn player_pause(&self) -> SpotifyRequest<'_, (), ()> {
+        self.request()
+            .method(Method::PUT)
+            .uri("/v1/me/player/pause".to_string(), None)
+    }
+
+    pub(crate) fn player_next(&self) -> SpotifyRequest<'_, (), ()> {
+        self.request()
+            .method(Method::PUT)
+            .uri("/v1/me/player/next".to_string(), None)
+    }
+
+    pub(crate) fn add_to_queue(&self, uri: String) -> SpotifyRequest<'_, (), ()> {
+        let query = make_query_params().append_pair("uri", &uri).finish();
+
+        self.request()
+            .method(Method::POST)
+            .uri("/v1/me/player/queue".to_string(), Some(&query))
+    }
+
+    pub(crate) fn player_previous(&self) -> SpotifyRequest<'_, (), ()> {
+        self.request()
+            .method(Method::PUT)
+            .uri("/v1/me/player/previous".to_string(), None)
+    }
+
+    pub(crate) fn player_seek(&self, pos: usize) -> SpotifyRequest<'_, (), ()> {
+        let query = make_query_params()
+            .append_pair("position_ms", &pos.to_string()[..])
+            .finish();
+
+        self.request()
+            .method(Method::PUT)
+            .uri("/v1/me/player/seek".to_string(), Some(&query))
+    }
 }
 
 #[cfg(test)]

--- a/src/app/components/player_notifier.rs
+++ b/src/app/components/player_notifier.rs
@@ -35,6 +35,9 @@ impl EventListener for PlayerNotifier {
             AppEvent::PlaybackEvent(PlaybackEvent::TrackSeeked(position)) => {
                 Some(Command::PlayerSeek(*position))
             }
+            AppEvent::PlaybackEvent(PlaybackEvent::SwitchDevice(device)) => {
+                Some(Command::SwitchDevice(*device))
+            }
             AppEvent::LoginEvent(LoginEvent::LoginStarted(LoginStartedEvent::Password {
                 username,
                 password,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,4 @@
-use crate::api::CachedSpotifyClient;
+use crate::api::{CachedSpotifyClient, SpotifyApiClient};
 use crate::settings::SpotSettings;
 use futures::channel::mpsc::UnboundedSender;
 use std::rc::Rc;
@@ -48,7 +48,7 @@ impl App {
         let model = Rc::new(AppModel::new(state, spotify_client));
 
         let components: Vec<Box<dyn EventListener>> = vec![
-            App::make_player_notifier(&settings, sender.clone()),
+            App::make_player_notifier(model.get_spotify(), &settings, sender.clone()),
             App::make_dbus(Rc::clone(&model), sender.clone()),
         ];
 
@@ -94,12 +94,13 @@ impl App {
     }
 
     fn make_player_notifier(
+        api: Arc<dyn SpotifyApiClient + Send + Sync>,
         settings: &SpotSettings,
         sender: UnboundedSender<AppAction>,
     ) -> Box<impl EventListener> {
         Box::new(PlayerNotifier::new(
             sender.clone(),
-            crate::player::start_player_service(settings.player_settings.clone(), sender),
+            crate::player::start_player_service(api, settings.player_settings.clone(), sender),
         ))
     }
 

--- a/src/app/state/playback_state.rs
+++ b/src/app/state/playback_state.rs
@@ -259,6 +259,12 @@ pub enum PlaylistChange {
     MovedDown(usize),
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum Device {
+    Local,
+    Connect,
+}
+
 #[derive(Clone, Debug)]
 pub enum PlaybackEvent {
     PlaybackPaused,
@@ -270,6 +276,7 @@ pub enum PlaybackEvent {
     ShuffleChanged,
     PlaylistChanged(PlaylistChange),
     PlaybackStopped,
+    SwitchDevice(Device),
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
Adds a basic spotify connect implementation closing #55 

TODO:
 - [ ] Switching between devices
 - [ ] Selecting connect device
 - [ ] Handle end of track etc
