### PR TITLE
playback-info: add .body style

### DIFF
--- a/src/app/components/playback/playback_info.ui
+++ b/src/app/components/playback/playback_info.ui
@@ -37,5 +37,8 @@
                 </child>
             </object>
         </child>
+        <style>
+		    <class name="body"/>
+		</style>
     </template>
 </interface>


### PR DESCRIPTION
Overrides Adwaita's bold weight styling for buttons:
![image](https://user-images.githubusercontent.com/27908024/141766205-cb6d5541-2092-437d-ba63-fbcd65800ab5.png)
