### PR TITLE
Use tabular numbers, ratio symbol for durations

### DIFF
--- a/src/app/components/playback/playback_widget.rs
+++ b/src/app/components/playback/playback_widget.rs
@@ -112,7 +112,7 @@ impl PlaybackWidget {
             style_context.add_class(class);
             widget.seek_bar.set_range(0.0, duration);
             widget.seek_bar.set_value(0.0);
-            widget.track_position.set_text("0:00");
+            widget.track_position.set_text("0∶00");
             widget
                 .track_duration
                 .set_text(&format!(" / {}", format_duration(duration)));

--- a/src/app/components/playback/playback_widget.ui
+++ b/src/app/components/playback/playback_widget.ui
@@ -66,16 +66,22 @@
                 <child>
                   <object class="GtkLabel" id="track_position">
                     <property name="sensitive">0</property>
-                    <property name="label">0:00</property>
+                    <property name="label">0∶00</property>
                     <property name="halign">end</property>
                     <property name="hexpand">1</property>
+										<style>
+											<class name="numeric"/>
+										</style>
                   </object>
                 </child>
                 <child>
                   <object class="GtkLabel" id="track_duration">
                     <property name="sensitive">0</property>
-                    <property name="label"> / 0:00</property>
+                    <property name="label"> / 0∶00</property>
                     <property name="halign">end</property>
+										<style>
+											<class name="numeric"/>
+										</style>
                   </object>
                 </child>
               </object>

--- a/src/app/components/playlist/song.ui
+++ b/src/app/components/playlist/song.ui
@@ -21,6 +21,7 @@
             <property name="label">1</property>
             <style>
               <class name="song__index"/>
+              <class name="numeric"/>
             </style>
           </object>
         </child>
@@ -89,7 +90,7 @@
     <child>
       <object class="GtkLabel" id="song_length">
         <property name="sensitive">0</property>
-        <property name="label">0:00</property>
+        <property name="label">0∶00</property>
         <property name="max-width-chars">35</property>
         <property name="xalign">1</property>
         <property name="hexpand">0</property>
@@ -100,6 +101,7 @@
         </layout>
         <style>
           <class name="song__duration"/>
+          <class name="numeric"/>
         </style>
       </object>
     </child>

--- a/src/app/components/utils.rs
+++ b/src/app/components/utils.rs
@@ -145,8 +145,8 @@ pub fn format_duration(duration: f64) -> String {
     let minutes = seconds.div_euclid(60).rem_euclid(60);
     let seconds = seconds.rem_euclid(60);
     if hours > 0 {
-        format!("{}:{:02}:{:02}", hours, minutes, seconds)
+        format!("{}∶{:02}∶{:02}", hours, minutes, seconds)
     } else {
-        format!("{}:{:02}", minutes, seconds)
+        format!("{}∶{:02}", minutes, seconds)
     }
 }


### PR DESCRIPTION
Very subtle change to how song durations are displayed: U+2236 Ratio is used instead of colon, .numeric style is applied to make the numbers tabular (as in having the numbers take the same space, allowing them to align better), as per HIG.

![image](https://user-images.githubusercontent.com/27908024/143183523-94a859a1-1594-412c-851c-5bb2150598d1.png)
