### PR TITLE
Define accent_color as well

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,5 @@
 @define-color accent_bg_color @green_5;
-
+@define-color accent_color @green_3
 .notification {
   opacity: 0;
   transition: opacity 0.3s ease;


### PR DESCRIPTION
Apparently needed for things like focus rings:
![image](https://user-images.githubusercontent.com/27908024/144708486-a2529781-bbb9-4932-94af-14986384f15b.png)
