### PR TITLE
Align album track song indices

### DIFF
--- a/src/app/components/playlist/song.css
+++ b/src/app/components/playlist/song.css
@@ -3,6 +3,7 @@
   margin: 6px 12px;
   padding: 0;
   opacity: 1;
+  min-width: 1.5em;
 }
 
 .song__cover {

--- a/src/app/components/playlist/song.ui
+++ b/src/app/components/playlist/song.ui
@@ -19,6 +19,7 @@
           <object class="GtkLabel" id="song_index">
             <property name="label">1</property>
             <property name="sensitive">0</property>
+            <property name="halign">GTK_ALIGN_CENTER</property>
             <style>
               <class name="song__index"/>
               <class name="numeric"/>


### PR DESCRIPTION
Fixes #208. Spotify appears to reset the track index every 80
songs so 1.5em (enough for two digits) seems to be good
enough.

Tested by viewing the Thirukkural album which contains 1330
tracks. Seems to work well and everything is aligned.