### PR TITLE
Add GenericName to desktop entry file

### DIFF
--- a/data/dev.alextren.Spot.desktop
+++ b/data/dev.alextren.Spot.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=Spot
+GenericName=Music Player
 Exec=spot
 Icon=dev.alextren.Spot
 Terminal=false


### PR DESCRIPTION
Having a generic name in the desktop entry adds some useful context.