### PR TITLE
Use GtkPasswordEntry

### DIFF
--- a/src/app/components/login/login.rs
+++ b/src/app/components/login/login.rs
@@ -31,9 +31,6 @@ mod imp {
         pub login_button: TemplateChild<gtk::Button>,
 
         #[template_child]
-        pub caps_lock_info_container: TemplateChild<gtk::Revealer>,
-
-        #[template_child]
         pub auth_error_container: TemplateChild<gtk::Revealer>,
     }
 
@@ -88,7 +85,6 @@ impl LoginWindow {
         controller.set_propagation_phase(gtk::PropagationPhase::Capture);
         controller.connect_key_pressed(
             clone!(@weak self as _self => @default-return gtk::Inhibit(false), move |_, key, _, modifier| {
-                _self.show_caps_lock_info((modifier == gdk::ModifierType::LOCK_MASK) ^ (key == gdk::Key::Caps_Lock));
                 if key == gdk::Key::Return {
                     _self.submit(&on_submit_clone);
                     gtk::Inhibit(true)
@@ -109,11 +105,6 @@ impl LoginWindow {
     fn show_auth_error(&self, shown: bool) {
         let widget = imp::LoginWindow::from_instance(self);
         widget.auth_error_container.set_reveal_child(shown);
-    }
-
-    fn show_caps_lock_info(&self, shown: bool) {
-        let widget = imp::LoginWindow::from_instance(self);
-        widget.caps_lock_info_container.set_reveal_child(shown);
     }
 
     fn submit<SubmitFn>(&self, on_submit: &SubmitFn)

--- a/src/app/components/login/login.ui
+++ b/src/app/components/login/login.ui
@@ -42,7 +42,7 @@
                       <object class="GtkLabel">
                         <property name="halign">start</property>
                         <property name="valign">start</property>
-                        <property name="label" translatable="yes" comments="Login window title -- shouldn&apos;t be too long, but must mention Premium (a premium account is required).">Login to Spotify Premium</property>
+                        <property name="label" translatable="yes" comments="Login window title -- shouldn&apos;t be too long, but must mention Premium (af premium account is required).">Login to Spotify Premium</property>
                         <property name="wrap">1</property>
                         <property name="xalign">0</property>
                         <property name="yalign">0</property>
@@ -59,50 +59,38 @@
                         <property name="orientation">vertical</property>
                         <property name="spacing">4</property>
                         <child>
-                          <object class="GtkEntry" id="username">
-                            <property name="primary-icon-name">avatar-default-symbolic</property>
-                            <property name="placeholder-text" translatable="yes" comments="Placeholder for the username field">Username</property>
+                          <object class="GtkBox">
+                            <property name="orientation">horizontal</property>
+                            <property name="spacing">4</property>
+                            <child>
+                              <object class="GtkImage" id="username-icon">
+                                <property name="icon-name">avatar-default-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="username">
+                                <property name="placeholder-text" translatable="yes" comments="Placeholder for the username field">Username</property>
+                              </object>
+                            </child>
                           </object>
                         </child>
                         <child>
-                          <object class="GtkEntry" id="password">
-                            <property name="visibility">0</property>
-                            <property name="invisible-char">●</property>
-                            <property name="primary-icon-name">dialog-password-symbolic</property>
-                            <property name="placeholder-text" translatable="yes" comments="Placeholder for the password field">Password</property>
+                          <object class="GtkBox">
+                            <property name="orientation">horizontal</property>
+                            <property name="spacing">4</property>
+                            <child>
+                              <object class="GtkImage" id="password-icon">
+                                <property name="icon-name">dialog-password-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                             <object class="GtkPasswordEntry" id="password">
+                               <property name="show-peek-icon">1</property>
+                               <property name="placeholder-text" translatable="yes" comments="Placeholder for the password field">Password</property>
+                             </object>
+                            </child>
                           </object>
                         </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkRevealer" id="caps_lock_info_container">
-                        <property name="vexpand">1</property>
-                        <property name="transition-type">slide-up</property>
-                        <property name="child">
-                          <object class="GtkBox">
-                            <property name="spacing">8</property>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="halign">center</property>
-                                <property name="valign">start</property>
-                                <property name="margin-top">2</property>
-                                <property name="vexpand">1</property>
-                                <property name="icon-name">dialog-information-symbolic</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label" translatable="yes" comments="This information is shown when Caps Lock is enabled.">Caps Lock is enabled!</property>
-                                <property name="wrap">1</property>
-                                <property name="xalign">0</property>
-                                <property name="yalign">0</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"></attribute>
-                                </attributes>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
                       </object>
                     </child>
                     <child>


### PR DESCRIPTION
This should fix issue #380 by using the GtkPasswordEntry on the login screen.

![grafik](https://user-images.githubusercontent.com/22551563/158502971-c4148a1c-b719-464b-be5a-1a46bdb83e31.png)

Thereby I removed the home-brew caps lock notification and placed the icons in front of the entries since GtkPasswordEntry does not support primary-icon-name.

One minor remark: I would rather centre all stuff in the dialogue because now I find it quite off looking but since this wasn't the point here I left it untouched.

Also, I don't know how to prune the msgids of the caps lock notification in the potfiles.
