### PR TITLE
Nest "More from artist" menu entries in submenu

### DIFF
--- a/src/app/components/artist_details/artist_details_model.rs
+++ b/src/app/components/artist_details/artist_details_model.rs
@@ -123,11 +123,27 @@ impl PlaylistModel for ArtistDetailsModel {
 
         let menu = gio::Menu::new();
         menu.append(Some(&*labels::VIEW_ALBUM), Some("song.view_album"));
-        for artist in song.artists.iter().filter(|a| self.id != a.id) {
-            menu.append(
-                Some(&labels::more_from_label(&artist.name)),
-                Some(&format!("song.view_artist_{}", artist.id)),
-            );
+
+        let artists_iter = song.artists.iter();
+
+        if artists_iter.len() > 1 {
+            let submenu = gio::Menu::new();
+
+            for artist in artists_iter {
+                submenu.append(
+                    Some(&artist.name),
+                    Some(&format!("song.view_artist_{}", artist.id)),
+                );
+            }
+
+            menu.append_submenu(Some("More from"), &submenu);
+        } else {
+            for artist in artists_iter {
+                menu.append(
+                    Some(&labels::more_from_label(&artist.name)),
+                    Some(&format!("song.view_artist_{}", artist.id)),
+                );
+            }
         }
 
         menu.append(Some(&*labels::COPY_LINK), Some("song.copy_link"));

--- a/src/app/components/details/details_model.rs
+++ b/src/app/components/details/details_model.rs
@@ -204,11 +204,27 @@ impl PlaylistModel for DetailsModel {
         let song = song.description();
 
         let menu = gio::Menu::new();
-        for artist in song.artists.iter() {
-            menu.append(
-                Some(&labels::more_from_label(&artist.name)),
-                Some(&format!("song.view_artist_{}", artist.id)),
-            );
+
+        let artists_iter = song.artists.iter();
+
+        if artists_iter.len() > 1 {
+            let submenu = gio::Menu::new();
+
+            for artist in artists_iter {
+                submenu.append(
+                    Some(&artist.name),
+                    Some(&format!("song.view_artist_{}", artist.id)),
+                );
+            }
+
+            menu.append_submenu(Some("More from"), &submenu);
+        } else {
+            for artist in artists_iter {
+                menu.append(
+                    Some(&labels::more_from_label(&artist.name)),
+                    Some(&format!("song.view_artist_{}", artist.id)),
+                );
+            }
         }
 
         menu.append(Some(&*labels::COPY_LINK), Some("song.copy_link"));

--- a/src/app/components/now_playing/now_playing_model.rs
+++ b/src/app/components/now_playing/now_playing_model.rs
@@ -90,11 +90,27 @@ impl PlaylistModel for NowPlayingModel {
 
         let menu = gio::Menu::new();
         menu.append(Some(&*labels::VIEW_ALBUM), Some("song.view_album"));
-        for artist in song.artists.iter() {
-            menu.append(
-                Some(&labels::more_from_label(&artist.name)),
-                Some(&format!("song.view_artist_{}", artist.id)),
-            );
+
+        let artists_iter = song.artists.iter();
+
+        if artists_iter.len() > 1 {
+            let submenu = gio::Menu::new();
+
+            for artist in artists_iter {
+                submenu.append(
+                    Some(&artist.name),
+                    Some(&format!("song.view_artist_{}", artist.id)),
+                );
+            }
+
+            menu.append_submenu(Some("More from"), &submenu);
+        } else {
+            for artist in artists_iter {
+                menu.append(
+                    Some(&labels::more_from_label(&artist.name)),
+                    Some(&format!("song.view_artist_{}", artist.id)),
+                );
+            }
         }
 
         menu.append(Some(&*labels::COPY_LINK), Some("song.copy_link"));

--- a/src/app/components/playlist_details/playlist_details_model.rs
+++ b/src/app/components/playlist_details/playlist_details_model.rs
@@ -142,11 +142,27 @@ impl PlaylistModel for PlaylistDetailsModel {
 
         let menu = gio::Menu::new();
         menu.append(Some(&*labels::VIEW_ALBUM), Some("song.view_album"));
-        for artist in song.artists.iter() {
-            menu.append(
-                Some(&labels::more_from_label(&artist.name)),
-                Some(&format!("song.view_artist_{}", artist.id)),
-            );
+
+        let artists_iter = song.artists.iter();
+
+        if artists_iter.len() > 1 {
+            let submenu = gio::Menu::new();
+
+            for artist in artists_iter {
+                submenu.append(
+                    Some(&artist.name),
+                    Some(&format!("song.view_artist_{}", artist.id)),
+                );
+            }
+
+            menu.append_submenu(Some("More from"), &submenu);
+        } else {
+            for artist in artists_iter {
+                menu.append(
+                    Some(&labels::more_from_label(&artist.name)),
+                    Some(&format!("song.view_artist_{}", artist.id)),
+                );
+            }
         }
 
         menu.append(Some(&*labels::COPY_LINK), Some("song.copy_link"));

--- a/src/app/components/saved_tracks/saved_tracks_model.rs
+++ b/src/app/components/saved_tracks/saved_tracks_model.rs
@@ -107,11 +107,27 @@ impl PlaylistModel for SavedTracksModel {
 
         let menu = gio::Menu::new();
         menu.append(Some(&*labels::VIEW_ALBUM), Some("song.view_album"));
-        for artist in song.artists.iter() {
-            menu.append(
-                Some(&labels::more_from_label(&artist.name)),
-                Some(&format!("song.view_artist_{}", artist.id)),
-            );
+
+        let artists_iter = song.artists.iter();
+
+        if artists_iter.len() > 1 {
+            let submenu = gio::Menu::new();
+
+            for artist in artists_iter {
+                submenu.append(
+                    Some(&artist.name),
+                    Some(&format!("song.view_artist_{}", artist.id)),
+                );
+            }
+
+            menu.append_submenu(Some("More from"), &submenu);
+        } else {
+            for artist in artists_iter {
+                menu.append(
+                    Some(&labels::more_from_label(&artist.name)),
+                    Some(&format!("song.view_artist_{}", artist.id)),
+                );
+            }
         }
 
         menu.append(Some(&*labels::COPY_LINK), Some("song.copy_link"));


### PR DESCRIPTION
Previously, every listed artist had its own "More from artist" menu entry, this commit nests them in a submenu with each entry representing an artist. Songs with a single artist are not affected.

Submenu:
![screenshot1](https://user-images.githubusercontent.com/40997689/174899644-bd001ae3-e17a-4d1c-84e5-a7b805ed7134.png)

Entries in submenu:
![screenshot2](https://user-images.githubusercontent.com/40997689/174899660-38c99d32-97f4-4bfe-ad6b-c988f598f36a.png)

