### PR TITLE
Implement track preloading for gapless playback

### DIFF
--- a/data/dev.alextren.Spot.gschema.xml
+++ b/data/dev.alextren.Spot.gschema.xml
@@ -34,6 +34,10 @@
       <default>'pulseaudio'</default>
       <summary>Audio backend</summary>
     </key>
+    <key name="gapless-playback" type="b">
+      <default>true</default>
+      <summary>A flag to enable gap-less playback</summary>
+    </key>
     <key name='alsa-device' type='s'>
       <default>'default'</default>
       <summary>Alsa device (if audio backend is 'alsa')</summary>

--- a/src/app/components/player_notifier.rs
+++ b/src/app/components/player_notifier.rs
@@ -35,6 +35,9 @@ impl EventListener for PlayerNotifier {
             AppEvent::PlaybackEvent(PlaybackEvent::TrackChanged(id)) => {
                 SpotifyId::from_base62(id).ok().map(Command::PlayerLoad)
             }
+            AppEvent::PlaybackEvent(PlaybackEvent::Preload(id)) => {
+                SpotifyId::from_base62(id).ok().map(Command::PlayerPreload)
+            }
             AppEvent::PlaybackEvent(PlaybackEvent::TrackSeeked(position)) => {
                 Some(Command::PlayerSeek(*position))
             }

--- a/src/app/components/settings/settings.rs
+++ b/src/app/components/settings/settings.rs
@@ -32,6 +32,9 @@ mod imp {
         pub audio_backend: TemplateChild<libadwaita::ComboRow>,
 
         #[template_child]
+        pub gapless_playback: TemplateChild<libadwaita::ActionRow>,
+
+        #[template_child]
         pub ap_port: TemplateChild<gtk::Entry>,
 
         #[template_child]
@@ -160,6 +163,14 @@ impl SettingsWindow {
                     .to_variant()
                 })
             })
+            .build();
+
+        let gapless_playback = widget
+            .gapless_playback
+            .downcast_ref::<libadwaita::ActionRow>()
+            .unwrap();
+        settings
+            .bind("gapless-playback", &gapless_playback.activatable_widget().unwrap(), "active")
             .build();
 
         let ap_port = widget.ap_port.downcast_ref::<gtk::Entry>().unwrap();

--- a/src/app/components/settings/settings.rs
+++ b/src/app/components/settings/settings.rs
@@ -169,7 +169,11 @@ impl SettingsWindow {
             .downcast_ref::<libadwaita::ActionRow>()
             .unwrap();
         settings
-            .bind("gapless-playback", &gapless_playback.activatable_widget().unwrap(), "active")
+            .bind(
+                "gapless-playback",
+                &gapless_playback.activatable_widget().unwrap(),
+                "active",
+            )
             .build();
 
         let ap_port = widget.ap_port.downcast_ref::<gtk::Entry>().unwrap();

--- a/src/app/components/settings/settings.ui
+++ b/src/app/components/settings/settings.ui
@@ -49,6 +49,20 @@
                 </property>
               </object>
             </child>
+            <child>
+              <object id="gapless_playback" class="AdwActionRow">
+                <property name="title" translatable="yes" comments="Title for an item in preferences">Gapless playback</property>
+                <property name="name">gapless_playback_row</property>
+                <property name="activatable_widget">gapless_playback_switch</property>
+                <property name="visible">True</property>
+                <child>
+                  <object id="gapless_playback_switch" class="GtkSwitch">
+                    <property name="margin-top">12</property>
+                    <property name="margin-bottom">12</property>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
         <child>

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -23,6 +23,7 @@ pub enum Command {
     PlayerStop,
     PlayerSeek(u32),
     PlayerSetVolume(f64),
+    PlayerPreload(SpotifyId),
     RefreshToken,
     ReloadSettings,
 }
@@ -92,6 +93,13 @@ impl SpotifyPlayerDelegate for AppPlayerDelegate {
         self.sender
             .borrow_mut()
             .unbounded_send(PlaybackAction::SyncSeek(position).into())
+            .unwrap();
+    }
+
+    fn preload_next_track(&self) {
+        self.sender
+            .borrow_mut()
+            .unbounded_send(PlaybackAction::Preload.into())
             .unwrap();
     }
 }

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -50,6 +50,7 @@ pub trait SpotifyPlayerDelegate {
     fn refresh_successful(&self, token: String, token_expiry_time: SystemTime);
     fn report_error(&self, error: SpotifyError);
     fn notify_playback_state(&self, position: u32);
+    fn preload_next_track(&self);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -129,6 +130,11 @@ impl SpotifyPlayer {
             Command::PlayerLoad(track) => {
                 let player = player.as_mut().ok_or(SpotifyError::PlayerNotReady)?;
                 player.load(track, true, 0);
+                Ok(())
+            }
+            Command::PlayerPreload(track) => {
+                let player = player.as_mut().ok_or(SpotifyError::PlayerNotReady)?;
+                player.preload(track);
                 Ok(())
             }
             Command::RefreshToken => {
@@ -330,6 +336,9 @@ async fn player_setup_delegate(
             }
             PlayerEvent::Playing { position_ms, .. } => {
                 delegate.notify_playback_state(position_ms);
+            }
+            PlayerEvent::TimeToPreloadNextTrack { .. } => {
+                delegate.preload_next_track();
             }
             _ => {}
         }

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -62,6 +62,7 @@ pub enum AudioBackend {
 pub struct SpotifyPlayerSettings {
     pub bitrate: Bitrate,
     pub backend: AudioBackend,
+    pub gapless: bool,
     pub ap_port: Option<u16>,
 }
 
@@ -69,6 +70,7 @@ impl Default for SpotifyPlayerSettings {
     fn default() -> Self {
         Self {
             bitrate: Bitrate::Bitrate160,
+            gapless: true,
             backend: AudioBackend::PulseAudio,
             ap_port: None,
         }
@@ -202,6 +204,7 @@ impl SpotifyPlayer {
         let backend = settings.backend.clone();
 
         let player_config = PlayerConfig {
+            gapless: settings.gapless,
             bitrate: settings.bitrate,
             ..Default::default()
         };

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -141,8 +141,10 @@ impl SpotifyPlayer {
                 Ok(())
             }
             Command::PlayerPreload(track) => {
-                let player = player.as_mut().ok_or(SpotifyError::PlayerNotReady)?;
-                player.preload(track);
+                self.player
+                    .as_mut()
+                    .ok_or(SpotifyError::PlayerNotReady)?
+                    .preload(track);
                 Ok(())
             }
             Command::RefreshToken => {
@@ -347,6 +349,7 @@ async fn player_setup_delegate(
                 delegate.notify_playback_state(position_ms);
             }
             PlayerEvent::TimeToPreloadNextTrack { .. } => {
+                debug!("Requestiong next track to be preloaded...");
                 delegate.preload_next_track();
             }
             _ => {}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -50,6 +50,8 @@ impl SpotifyPlayerSettings {
             )),
             _ => None,
         }?;
+        let gapless = settings.boolean("gapless-playback");
+
         let ap_port_val = settings.uint("ap-port");
         if ap_port_val > 65535 {
             panic!("Invalid access point port");
@@ -66,6 +68,7 @@ impl SpotifyPlayerSettings {
         Some(Self {
             bitrate,
             backend,
+            gapless,
             ap_port,
         })
     }


### PR DESCRIPTION
This adds librespot track preloading and a new setting for gapless playback.

Fixes #193 and #502.