### PR TITLE
Feature / Fix?: Follow the system theme

### DIFF
--- a/data/dev.alextren.Spot.gschema.xml
+++ b/data/dev.alextren.Spot.gschema.xml
@@ -9,10 +9,15 @@
     <value value="1" nick="160"/>
     <value value="2" nick="320"/>
   </enum>
+  <enum id="dev.alextren.Spot.ThemePref">
+    <value value="0" nick="light" />
+    <value value="1" nick="dark" />
+    <value value="2" nick="system" />
+  </enum>
   <schema id="dev.alextren.Spot" path="/dev/alextren/Spot/">
-    <key name='prefers-dark-theme' type='b'>
-      <default>true</default>
-      <summary>Prefer dark theme</summary>
+    <key name='theme-preference' enum='dev.alextren.Spot.ThemePref'>
+      <default>'system'</default>
+      <summary>The theme preference</summary>
     </key>
     <key name="window-width" type="i">
       <default>1080</default>

--- a/src/app/components/settings/settings.rs
+++ b/src/app/components/settings/settings.rs
@@ -168,10 +168,7 @@ impl SettingsWindow {
             .set_mapping(|value, _| value.get::<u32>().ok().map(|u| u.to_variant()))
             .build();
 
-        let theme = widget
-            .theme
-            .downcast_ref::<libadwaita::ComboRow>()
-            .unwrap();
+        let theme = widget.theme.downcast_ref::<libadwaita::ComboRow>().unwrap();
         settings
             .bind("theme-preference", theme, "selected")
             .mapping(|variant, _| {

--- a/src/app/components/settings/settings.ui
+++ b/src/app/components/settings/settings.ui
@@ -62,6 +62,7 @@
                     <items>
                       <item translatable="yes">Light</item>
                       <item translatable="yes">Dark</item>
+                      <item translatable="yes">System</item>
                     </items>
                   </object>
                 </property>

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use gio::prelude::*;
 use gio::ApplicationFlags;
 use gio::SimpleAction;
 use gtk::prelude::*;
-use libadwaita::ColorScheme;
 
 mod api;
 mod app;
@@ -98,11 +97,7 @@ fn startup(settings: &settings::SpotSettings) {
         .expect("Could not load resources");
     gio::resources_register(&res);
 
-    manager.set_color_scheme(if settings.prefers_dark_theme {
-        ColorScheme::PreferDark
-    } else {
-        ColorScheme::PreferLight
-    });
+    manager.set_color_scheme(settings.theme_preference);
 
     let provider = gtk::CssProvider::new();
     provider.load_from_resource("/dev/alextren/Spot/app.css");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,7 @@
 use crate::player::{AudioBackend, SpotifyPlayerSettings};
 use gio::prelude::SettingsExt;
 use librespot::playback::config::Bitrate;
+use libadwaita::ColorScheme;
 
 const SETTINGS: &str = "dev.alextren.Spot";
 
@@ -73,7 +74,7 @@ impl SpotifyPlayerSettings {
 
 #[derive(Debug, Clone)]
 pub struct SpotSettings {
-    pub prefers_dark_theme: bool,
+    pub theme_preference: ColorScheme,
     pub player_settings: SpotifyPlayerSettings,
     pub window: WindowGeometry,
 }
@@ -81,9 +82,14 @@ pub struct SpotSettings {
 impl SpotSettings {
     pub fn new_from_gsettings() -> Option<Self> {
         let settings = gio::Settings::new(SETTINGS);
-        let prefers_dark_theme = settings.boolean("prefers-dark-theme");
+        let theme_preference = match settings.enum_("theme-preference") {
+            0 => Some(ColorScheme::ForceLight),
+            1 => Some(ColorScheme::ForceDark),
+            2 => Some(ColorScheme::Default),
+            _ => None,
+        }?;
         Some(Self {
-            prefers_dark_theme,
+            theme_preference,
             player_settings: SpotifyPlayerSettings::new_from_gsettings()?,
             window: WindowGeometry::new_from_gsettings(),
         })
@@ -93,7 +99,7 @@ impl SpotSettings {
 impl Default for SpotSettings {
     fn default() -> Self {
         Self {
-            prefers_dark_theme: true,
+            theme_preference: ColorScheme::PreferDark,
             player_settings: Default::default(),
             window: Default::default(),
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,7 @@
 use crate::player::{AudioBackend, SpotifyPlayerSettings};
 use gio::prelude::SettingsExt;
-use librespot::playback::config::Bitrate;
 use libadwaita::ColorScheme;
+use librespot::playback::config::Bitrate;
 
 const SETTINGS: &str = "dev.alextren.Spot";
 


### PR DESCRIPTION
### Summary
The theme preference is now represented by an enum with 3 values:

  - light   => maps to libadwaita::ColorScheme::ForceLight
    The app uses the light theme - regardless of system prefs

  - dark    => maps to libadwaita::ColorScheme::ForceDark
    The app uses the dark theme - regardless of system prefs

  - system  => maps to libadwaita::ColorScheme::Default 
    The Apps style follows the system theme preferences

### Result
![image](https://user-images.githubusercontent.com/9384305/190166720-faff995d-8aec-43aa-9547-40015cb8c84f.png)
