### PR TITLE
Copy album and playlist link to clipboard

### DIFF
--- a/src/app/components/details/album_header.rs
+++ b/src/app/components/details/album_header.rs
@@ -20,6 +20,9 @@ mod imp {
         pub like_button: TemplateChild<gtk::Button>,
 
         #[template_child]
+        pub copy_button: TemplateChild<gtk::Button>,
+
+        #[template_child]
         pub info_button: TemplateChild<gtk::Button>,
 
         #[template_child]
@@ -74,6 +77,13 @@ impl AlbumHeaderWidget {
         F: Fn() + 'static,
     {
         self.widget().like_button.connect_clicked(move |_| f());
+    }
+
+    pub fn connect_copy<F>(&self, f: F)
+    where
+        F: Fn() + 'static,
+    {
+        self.widget().copy_button.connect_clicked(move |_| f());
     }
 
     pub fn connect_info<F>(&self, f: F)

--- a/src/app/components/details/album_header.ui
+++ b/src/app/components/details/album_header.ui
@@ -116,7 +116,6 @@
         <property name="icon-name">edit-copy</property>
         <style>
           <class name="circular" />
-          <class name="like__button" />
         </style>
       </object>
     </child>

--- a/src/app/components/details/album_header.ui
+++ b/src/app/components/details/album_header.ui
@@ -107,5 +107,18 @@
         </style>
       </object>
     </child>
+    <child>
+      <object class="GtkButton" id="copy_button">
+        <property name="receives-default">1</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="tooltip-text">Copy Link</property>
+        <property name="icon-name">edit-copy</property>
+        <style>
+          <class name="circular" />
+          <class name="like__button" />
+        </style>
+      </object>
+    </child>
   </template>
 </interface>

--- a/src/app/components/details/details.rs
+++ b/src/app/components/details/details.rs
@@ -165,6 +165,13 @@ impl AlbumDetailsWidget {
         self.widget().header_mobile.connect_info(f);
     }
 
+    fn connect_copy<F>(&self, f: F)
+    where
+        F: Fn() + Clone + 'static,
+    {
+        self.widget().header_widget.connect_copy(f.clone());
+    }
+
     fn set_liked(&self, is_liked: bool) {
         self.widget().header_widget.set_liked(is_liked);
         self.widget().header_mobile.set_liked(is_liked);
@@ -230,6 +237,8 @@ impl Details {
         let modal = ReleaseDetailsWindow::new();
 
         widget.connect_liked(clone!(@weak model => move || model.toggle_save_album()));
+
+        widget.connect_copy(clone!(@weak model => move || model.toggle_copy_link()));
 
         widget.connect_header_visibility();
 

--- a/src/app/components/details/details_model.rs
+++ b/src/app/components/details/details_model.rs
@@ -3,6 +3,7 @@ use gio::SimpleActionGroup;
 use std::cell::Ref;
 use std::ops::Deref;
 use std::rc::Rc;
+use gdk::prelude::*;
 
 use crate::api::SpotifyApiError;
 use crate::app::components::labels;
@@ -97,6 +98,15 @@ impl DetailsModel {
                     }
                 });
         }
+    }
+
+    pub fn toggle_copy_link(&self) {
+        let album_id = self.id.clone();
+        let link = format!("https://open.spotify.com/album/{}", &album_id);
+            let clipboard = gdk::Display::default().unwrap().clipboard();
+            clipboard
+                .set_content(Some(&gdk::ContentProvider::for_value(&link.to_value())))
+                .expect("Failed to set clipboard content");
     }
 
     pub fn load_more(&self) -> Option<()> {

--- a/src/app/components/playlist_details/playlist_details.rs
+++ b/src/app/components/playlist_details/playlist_details.rs
@@ -145,6 +145,14 @@ impl PlaylistDetailsWidget {
             .connect_artist_clicked(f.clone());
         self.widget().header_mobile.connect_artist_clicked(f);
     }
+
+    fn connect_copy<F>(&self, f: F)
+    where
+        F: Fn() + Clone + 'static,
+    {
+        self.widget().header_widget.connect_copy(f.clone());
+    }
+
 }
 
 pub struct PlaylistDetails {
@@ -175,6 +183,8 @@ impl PlaylistDetails {
         widget.connect_artist_clicked(clone!(@weak model => move || {
             model.view_owner();
         }));
+
+        widget.connect_copy(clone!(@weak model => move || model.toggle_copy_link()));
 
         Self {
             model,

--- a/src/app/components/playlist_details/playlist_details_model.rs
+++ b/src/app/components/playlist_details/playlist_details_model.rs
@@ -2,6 +2,7 @@ use gio::prelude::*;
 use gio::SimpleActionGroup;
 use std::ops::Deref;
 use std::rc::Rc;
+use gdk::prelude::*;
 
 use crate::api::SpotifyApiError;
 use crate::app::components::SimpleHeaderBarModel;
@@ -92,6 +93,16 @@ impl PlaylistDetailsModel {
                 .dispatch(AppAction::ViewUser(owner.to_owned()));
         }
     }
+
+    pub fn toggle_copy_link(&self) {
+        let id = self.id.clone();
+        let link = format!("https://open.spotify.com/playlist/{}", &id);
+            let clipboard = gdk::Display::default().unwrap().clipboard();
+            clipboard
+                .set_content(Some(&gdk::ContentProvider::for_value(&link.to_value())))
+                .expect("Failed to set clipboard content");
+    }
+
 }
 
 impl PlaylistModel for PlaylistDetailsModel {


### PR DESCRIPTION
I added the possibility to copy links for an album or playlist to the clipboard.
I implemented this by creating a copy-link-button in the album header widget.

This fixes issues #522 and #436 