### PR TITLE
Save tracks to library from dot menu

### DIFF
--- a/src/app/components/artist_details/artist_details_model.rs
+++ b/src/app/components/artist_details/artist_details_model.rs
@@ -113,6 +113,16 @@ impl PlaylistModel for ArtistDetailsModel {
         group.add_action(&song.make_album_action(self.dispatcher.box_clone(), None));
         group.add_action(&song.make_link_action(None));
         group.add_action(&song.make_queue_action(self.dispatcher.box_clone(), None));
+        group.add_action(&song.make_like_action(
+            self.dispatcher.box_clone(),
+            self.app_model.clone(),
+            None,
+        ));
+        group.add_action(&song.make_unlike_action(
+            self.dispatcher.box_clone(),
+            self.app_model.clone(),
+            None,
+        ));
 
         Some(group.upcast())
     }
@@ -132,6 +142,8 @@ impl PlaylistModel for ArtistDetailsModel {
 
         menu.append(Some(&*labels::COPY_LINK), Some("song.copy_link"));
         menu.append(Some(&*labels::ADD_TO_QUEUE), Some("song.queue"));
+        menu.append(Some(&*labels::ADD_TO_LIBRARY), Some("song.like"));
+        menu.append(Some(&*labels::REMOVE_FROM_LIBRARY), Some("song.unlike"));
         Some(menu.upcast())
     }
 

--- a/src/app/components/details/details_model.rs
+++ b/src/app/components/details/details_model.rs
@@ -195,6 +195,7 @@ impl PlaylistModel for DetailsModel {
         }
         group.add_action(&song.make_link_action(None));
         group.add_action(&song.make_queue_action(self.dispatcher.box_clone(), None));
+        group.add_action(&song.make_like_action(self.dispatcher.box_clone(),self.app_model.clone(), None));
 
         Some(group.upcast())
     }

--- a/src/app/components/details/details_model.rs
+++ b/src/app/components/details/details_model.rs
@@ -196,6 +196,7 @@ impl PlaylistModel for DetailsModel {
         group.add_action(&song.make_link_action(None));
         group.add_action(&song.make_queue_action(self.dispatcher.box_clone(), None));
         group.add_action(&song.make_like_action(self.dispatcher.box_clone(),self.app_model.clone(), None));
+        group.add_action(&song.make_unlike_action(self.dispatcher.box_clone(),self.app_model.clone(), None));
 
         Some(group.upcast())
     }
@@ -215,6 +216,7 @@ impl PlaylistModel for DetailsModel {
         menu.append(Some(&*labels::COPY_LINK), Some("song.copy_link"));
         menu.append(Some(&*labels::ADD_TO_QUEUE), Some("song.queue"));
         menu.append(Some(&*labels::ADD_TO_LIBRARY), Some("song.like"));
+        menu.append(Some(&*labels::REMOVE_FROM_LIBRARY), Some("song.unlike"));
         Some(menu.upcast())
     }
 }

--- a/src/app/components/details/details_model.rs
+++ b/src/app/components/details/details_model.rs
@@ -213,6 +213,7 @@ impl PlaylistModel for DetailsModel {
 
         menu.append(Some(&*labels::COPY_LINK), Some("song.copy_link"));
         menu.append(Some(&*labels::ADD_TO_QUEUE), Some("song.queue"));
+        menu.append(Some(&*labels::ADD_TO_LIBRARY), Some("song.like"));
         Some(menu.upcast())
     }
 }

--- a/src/app/components/details/details_model.rs
+++ b/src/app/components/details/details_model.rs
@@ -195,8 +195,16 @@ impl PlaylistModel for DetailsModel {
         }
         group.add_action(&song.make_link_action(None));
         group.add_action(&song.make_queue_action(self.dispatcher.box_clone(), None));
-        group.add_action(&song.make_like_action(self.dispatcher.box_clone(),self.app_model.clone(), None));
-        group.add_action(&song.make_unlike_action(self.dispatcher.box_clone(),self.app_model.clone(), None));
+        group.add_action(&song.make_like_action(
+            self.dispatcher.box_clone(),
+            self.app_model.clone(),
+            None,
+        ));
+        group.add_action(&song.make_unlike_action(
+            self.dispatcher.box_clone(),
+            self.app_model.clone(),
+            None,
+        ));
 
         Some(group.upcast())
     }

--- a/src/app/components/labels.rs
+++ b/src/app/components/labels.rs
@@ -12,6 +12,9 @@ lazy_static! {
 
     // translators: This is part of a contextual menu attached to a single track; this entry removes a track from the play queue.
     pub static ref REMOVE_FROM_QUEUE: String = gettext("Remove from queue");
+
+    // translators: This is part of a contextual menu attached to a single track; this entry adds a track to the library.
+    pub static ref ADD_TO_LIBRARY: String = gettext("Add to library");
 }
 
 pub fn add_to_playlist_label(playlist: &str) -> String {

--- a/src/app/components/labels.rs
+++ b/src/app/components/labels.rs
@@ -15,6 +15,9 @@ lazy_static! {
 
     // translators: This is part of a contextual menu attached to a single track; this entry adds a track to the library.
     pub static ref ADD_TO_LIBRARY: String = gettext("Add to library");
+
+    // translators: This is part of a contextual menu attached to a single track; this entry removes a track from the library.
+    pub static ref REMOVE_FROM_LIBRARY: String = gettext("Remove from library");
 }
 
 pub fn add_to_playlist_label(playlist: &str) -> String {

--- a/src/app/components/now_playing/now_playing_model.rs
+++ b/src/app/components/now_playing/now_playing_model.rs
@@ -79,6 +79,16 @@ impl PlaylistModel for NowPlayingModel {
         group.add_action(&song.make_album_action(self.dispatcher.box_clone(), None));
         group.add_action(&song.make_link_action(None));
         group.add_action(&song.make_dequeue_action(self.dispatcher.box_clone(), None));
+        group.add_action(&song.make_like_action(
+            self.dispatcher.box_clone(),
+            self.app_model.clone(),
+            None,
+        ));
+        group.add_action(&song.make_unlike_action(
+            self.dispatcher.box_clone(),
+            self.app_model.clone(),
+            None,
+        ));
 
         Some(group.upcast())
     }
@@ -99,6 +109,8 @@ impl PlaylistModel for NowPlayingModel {
 
         menu.append(Some(&*labels::COPY_LINK), Some("song.copy_link"));
         menu.append(Some(&*labels::REMOVE_FROM_QUEUE), Some("song.dequeue"));
+        menu.append(Some(&*labels::ADD_TO_LIBRARY), Some("song.like"));
+        menu.append(Some(&*labels::REMOVE_FROM_LIBRARY), Some("song.unlike"));
 
         Some(menu.upcast())
     }

--- a/src/app/components/playlist/song_actions.rs
+++ b/src/app/components/playlist/song_actions.rs
@@ -4,7 +4,7 @@ use gio::SimpleAction;
 use std::rc::Rc;
 
 use crate::app::models::SongDescription;
-use crate::app::state::{AppAction, PlaybackAction};
+use crate::app::state::{AppAction, PlaybackAction, SelectionAction};
 use crate::app::{ActionDispatcher, AppModel};
 
 impl SongDescription {
@@ -88,14 +88,17 @@ impl SongDescription {
         app_model: Rc<AppModel>,
         name: Option<&str>,
     ) -> SimpleAction {
-        let track_id = self.id.clone();
+        let track_id1 = self.id.clone();
+        let song = self.clone();
         let like_track = SimpleAction::new(name.unwrap_or("like"), None);
         like_track.connect_activate(move |_, _| {
-            let track_id = track_id.clone();
+            let track_id2 = track_id1.clone();
+            let song = song.clone();
             let api = app_model.get_spotify();
+            dispatcher.dispatch(SelectionAction::Select(vec![song]).into());
             dispatcher.call_spotify_and_dispatch_many(move || async move {
-                api.save_tracks(vec![track_id]).await?;
-                Ok(vec![AppAction::ShowNotification(gettext("Track saved!"))])
+                api.save_tracks(vec![track_id2]).await?;
+                Ok(vec![AppAction::SaveSelection, AppAction::ShowNotification(gettext("Track saved!"))])
             });
         });
         like_track
@@ -107,14 +110,17 @@ impl SongDescription {
         app_model: Rc<AppModel>,
         name: Option<&str>,
     ) -> SimpleAction {
-        let track_id = self.id.clone();
+        let track_id1 = self.id.clone();
+        let song = self.clone();
         let unlike_track = SimpleAction::new(name.unwrap_or("unlike"), None);
         unlike_track.connect_activate(move |_, _| {
-            let track_id = track_id.clone();
+            let track_id2 = track_id1.clone();
+            let song = song.clone();
             let api = app_model.get_spotify();
+            dispatcher.dispatch(SelectionAction::Select(vec![song]).into());
             dispatcher.call_spotify_and_dispatch_many(move || async move {
-                api.remove_saved_tracks(vec![track_id]).await?;
-                Ok(vec![AppAction::ShowNotification(gettext("Track unsaved!"))])
+                api.remove_saved_tracks(vec![track_id2]).await?;
+                Ok(vec![AppAction::UnsaveSelection, AppAction::ShowNotification(gettext("Track unsaved!"))])
             });
         });
         unlike_track

--- a/src/app/components/playlist/song_actions.rs
+++ b/src/app/components/playlist/song_actions.rs
@@ -82,35 +82,39 @@ impl SongDescription {
             .collect()
     }
 
-    pub fn make_like_action(&self, dispatcher: Box<dyn ActionDispatcher>, app_model: Rc<AppModel>, name: Option<&str>)-> SimpleAction {
+    pub fn make_like_action(
+        &self,
+        dispatcher: Box<dyn ActionDispatcher>,
+        app_model: Rc<AppModel>,
+        name: Option<&str>,
+    ) -> SimpleAction {
         let track_id = self.id.clone();
         let like_track = SimpleAction::new(name.unwrap_or("like"), None);
         like_track.connect_activate(move |_, _| {
-            let track_id  = track_id.clone();
+            let track_id = track_id.clone();
             let api = app_model.get_spotify();
-            dispatcher
-            .call_spotify_and_dispatch_many(move || async move {
+            dispatcher.call_spotify_and_dispatch_many(move || async move {
                 api.save_tracks(vec![track_id]).await?;
-                Ok(vec![
-                    AppAction::ShowNotification(gettext("Track saved!")),
-                ])
+                Ok(vec![AppAction::ShowNotification(gettext("Track saved!"))])
             });
         });
         like_track
     }
 
-    pub fn make_unlike_action(&self, dispatcher: Box<dyn ActionDispatcher>, app_model: Rc<AppModel>, name: Option<&str>)-> SimpleAction {
+    pub fn make_unlike_action(
+        &self,
+        dispatcher: Box<dyn ActionDispatcher>,
+        app_model: Rc<AppModel>,
+        name: Option<&str>,
+    ) -> SimpleAction {
         let track_id = self.id.clone();
         let unlike_track = SimpleAction::new(name.unwrap_or("unlike"), None);
         unlike_track.connect_activate(move |_, _| {
-            let track_id  = track_id.clone();
+            let track_id = track_id.clone();
             let api = app_model.get_spotify();
-            dispatcher
-            .call_spotify_and_dispatch_many(move || async move {
+            dispatcher.call_spotify_and_dispatch_many(move || async move {
                 api.remove_saved_tracks(vec![track_id]).await?;
-                Ok(vec![
-                    AppAction::ShowNotification(gettext("Track unsaved!")),
-                ])
+                Ok(vec![AppAction::ShowNotification(gettext("Track unsaved!"))])
             });
         });
         unlike_track

--- a/src/app/components/playlist/song_actions.rs
+++ b/src/app/components/playlist/song_actions.rs
@@ -88,16 +88,16 @@ impl SongDescription {
         app_model: Rc<AppModel>,
         name: Option<&str>,
     ) -> SimpleAction {
-        let track_id1 = self.id.clone();
+        let track_id = self.id.clone();
         let song = self.clone();
         let like_track = SimpleAction::new(name.unwrap_or("like"), None);
         like_track.connect_activate(move |_, _| {
-            let track_id2 = track_id1.clone();
+            let track_id = track_id.clone();
             let song = song.clone();
             let api = app_model.get_spotify();
             dispatcher.dispatch(SelectionAction::Select(vec![song]).into());
             dispatcher.call_spotify_and_dispatch_many(move || async move {
-                api.save_tracks(vec![track_id2]).await?;
+                api.save_tracks(vec![track_id]).await?;
                 Ok(vec![
                     AppAction::SaveSelection,
                     AppAction::ShowNotification(gettext("Track saved!")),
@@ -113,16 +113,16 @@ impl SongDescription {
         app_model: Rc<AppModel>,
         name: Option<&str>,
     ) -> SimpleAction {
-        let track_id1 = self.id.clone();
+        let track_id = self.id.clone();
         let song = self.clone();
         let unlike_track = SimpleAction::new(name.unwrap_or("unlike"), None);
         unlike_track.connect_activate(move |_, _| {
-            let track_id2 = track_id1.clone();
+            let track_id = track_id.clone();
             let song = song.clone();
             let api = app_model.get_spotify();
             dispatcher.dispatch(SelectionAction::Select(vec![song]).into());
             dispatcher.call_spotify_and_dispatch_many(move || async move {
-                api.remove_saved_tracks(vec![track_id2]).await?;
+                api.remove_saved_tracks(vec![track_id]).await?;
                 Ok(vec![
                     AppAction::UnsaveSelection,
                     AppAction::ShowNotification(gettext("Track unsaved!")),

--- a/src/app/components/playlist/song_actions.rs
+++ b/src/app/components/playlist/song_actions.rs
@@ -98,7 +98,10 @@ impl SongDescription {
             dispatcher.dispatch(SelectionAction::Select(vec![song]).into());
             dispatcher.call_spotify_and_dispatch_many(move || async move {
                 api.save_tracks(vec![track_id2]).await?;
-                Ok(vec![AppAction::SaveSelection, AppAction::ShowNotification(gettext("Track saved!"))])
+                Ok(vec![
+                    AppAction::SaveSelection,
+                    AppAction::ShowNotification(gettext("Track saved!")),
+                ])
             });
         });
         like_track
@@ -120,7 +123,10 @@ impl SongDescription {
             dispatcher.dispatch(SelectionAction::Select(vec![song]).into());
             dispatcher.call_spotify_and_dispatch_many(move || async move {
                 api.remove_saved_tracks(vec![track_id2]).await?;
-                Ok(vec![AppAction::UnsaveSelection, AppAction::ShowNotification(gettext("Track unsaved!"))])
+                Ok(vec![
+                    AppAction::UnsaveSelection,
+                    AppAction::ShowNotification(gettext("Track unsaved!")),
+                ])
             });
         });
         unlike_track

--- a/src/app/components/playlist/song_actions.rs
+++ b/src/app/components/playlist/song_actions.rs
@@ -92,10 +92,27 @@ impl SongDescription {
             .call_spotify_and_dispatch_many(move || async move {
                 api.save_tracks(vec![track_id]).await?;
                 Ok(vec![
-                    AppAction::ShowNotification(gettext("Tracks saved!")),
+                    AppAction::ShowNotification(gettext("Track saved!")),
                 ])
             });
         });
         like_track
+    }
+
+    pub fn make_unlike_action(&self, dispatcher: Box<dyn ActionDispatcher>, app_model: Rc<AppModel>, name: Option<&str>)-> SimpleAction {
+        let track_id = self.id.clone();
+        let unlike_track = SimpleAction::new(name.unwrap_or("unlike"), None);
+        unlike_track.connect_activate(move |_, _| {
+            let track_id  = track_id.clone();
+            let api = app_model.get_spotify();
+            dispatcher
+            .call_spotify_and_dispatch_many(move || async move {
+                api.remove_saved_tracks(vec![track_id]).await?;
+                Ok(vec![
+                    AppAction::ShowNotification(gettext("Track unsaved!")),
+                ])
+            });
+        });
+        unlike_track
     }
 }

--- a/src/app/components/playlist_details/playlist_details_model.rs
+++ b/src/app/components/playlist_details/playlist_details_model.rs
@@ -132,6 +132,16 @@ impl PlaylistModel for PlaylistDetailsModel {
         group.add_action(&song.make_album_action(self.dispatcher.box_clone(), None));
         group.add_action(&song.make_link_action(None));
         group.add_action(&song.make_queue_action(self.dispatcher.box_clone(), None));
+        group.add_action(&song.make_like_action(
+            self.dispatcher.box_clone(),
+            self.app_model.clone(),
+            None,
+        ));
+        group.add_action(&song.make_unlike_action(
+            self.dispatcher.box_clone(),
+            self.app_model.clone(),
+            None,
+        ));
 
         Some(group.upcast())
     }
@@ -151,6 +161,8 @@ impl PlaylistModel for PlaylistDetailsModel {
 
         menu.append(Some(&*labels::COPY_LINK), Some("song.copy_link"));
         menu.append(Some(&*labels::ADD_TO_QUEUE), Some("song.queue"));
+        menu.append(Some(&*labels::ADD_TO_LIBRARY), Some("song.like"));
+        menu.append(Some(&*labels::REMOVE_FROM_LIBRARY), Some("song.unlike"));
 
         Some(menu.upcast())
     }

--- a/src/app/components/saved_tracks/saved_tracks_model.rs
+++ b/src/app/components/saved_tracks/saved_tracks_model.rs
@@ -97,6 +97,11 @@ impl PlaylistModel for SavedTracksModel {
         }
         group.add_action(&song.make_album_action(self.dispatcher.box_clone(), None));
         group.add_action(&song.make_link_action(None));
+        group.add_action(&song.make_unlike_action(
+            self.dispatcher.box_clone(),
+            self.app_model.clone(),
+            None,
+        ));
 
         Some(group.upcast())
     }
@@ -115,6 +120,7 @@ impl PlaylistModel for SavedTracksModel {
         }
 
         menu.append(Some(&*labels::COPY_LINK), Some("song.copy_link"));
+        menu.append(Some(&*labels::REMOVE_FROM_LIBRARY), Some("song.unlike"));
 
         Some(menu.upcast())
     }


### PR DESCRIPTION
This PR fixes #505. 

**Current status:**
At the moment, tracks can only be saved/removed through the multi-selection mode. In the 'saved tracks' view, tracks can be removed from the library through the multi-selection mode. In all other places they can be added to the library (but not removed, if they are already in the library).

**My implementation**:
I implemented the functionality to add/remove track to/from the library, through the **dot menu of a track**. This functionality also updates the 'saved tracks' view. Tracks can now be saved/unsaved from:
- Album
- Playlist
- Artist
- now playing 
- saved tracks (here, tracks can only be removed)

The issue description also suggests adding/removing tracks through a button in the now playing bar, but I decided against implementing the functionality that way, as I think it will clutter the UI too much.

**This is how the dot menu of a track looks now:**
![image](https://user-images.githubusercontent.com/60743257/197954363-0e43bd6b-6f8d-45bd-b2f3-502a92f888b6.png)


**Discussion/ Problem:**
I realized that currently there is no way of checking if a song is already in the library or not (maybe there is, but I just missed it, then let me know). So I always display the add and remove entry in the dot menu, however it would be cleaner to only display one, depending on the like-status of the song.
I also realized that at the moment tracks can be saved through the multi-selection mode in many places (playlist, album..) but not removed. Tracks can only be removed in the 'saved tracks' view, through the multi-selection mode.
Is this a design choice? Then I could also only display the 'add to library' entry in most places (playlist, album..), and the 'remove from library' only in the 'saved tracks' view

I'm more than happy to discuss these problems and change by PR