### PR TITLE
Try to unlock the keyring collection when it is locked

### DIFF
--- a/src/app/credentials.rs
+++ b/src/app/credentials.rs
@@ -30,6 +30,9 @@ impl Credentials {
     pub fn retrieve() -> Result<Self, Error> {
         let service = SecretService::new(EncryptionType::Dh)?;
         let collection = service.get_default_collection()?;
+        if collection.is_locked()? {
+            collection.unlock()?;
+        }
         let items = collection.search_items(make_attributes())?;
         let item = items.get(0).ok_or(Error::NoResult)?.get_secret()?;
         serde_json::from_slice(&item).map_err(|_| Error::Parse)
@@ -38,6 +41,9 @@ impl Credentials {
     pub fn logout() -> Result<(), Error> {
         let service = SecretService::new(EncryptionType::Dh)?;
         let collection = service.get_default_collection()?;
+        if collection.is_locked()? {
+            collection.unlock()?;
+        }
         let result = collection.search_items(make_attributes())?;
         let item = result.get(0).ok_or(Error::NoResult)?;
         item.delete()
@@ -46,6 +52,9 @@ impl Credentials {
     pub fn save(&self) -> Result<(), Error> {
         let service = SecretService::new(EncryptionType::Dh)?;
         let collection = service.get_default_collection()?;
+        if collection.is_locked()? {
+            collection.unlock()?;
+        }
         let encoded = serde_json::to_vec(&self).unwrap();
         collection.create_item(
             "Spotify Credentials",


### PR DESCRIPTION
On KDE plasma, the secret service is initially locked even though the kwallet is unlocked. Currently if spot is the first application to require the wallet it will fail to access it. My current workaround is to open another app that unlock the wallet and then opening spot.
With this PR, spot will try to unlock the keyring collection if it is locked, resulting on a prompt asking the user for the keyring password, if the keyring unlocking fail, the behavior should be the same as before.
It should help #274 at least on the KDE side. I tested this PR on KDE, can you check if no regression are present on GNOME ?