### PR TITLE
Play button for album and playlist

### DIFF
--- a/src/app/components/details/album_header.css
+++ b/src/app/components/details/album_header.css
@@ -18,6 +18,10 @@
   margin-right: 6px;
 }
 
+.album__header .play__button {
+  margin-right: 8px;
+}
+
 .album__header .vertical {
   margin-left: 18px;
 }

--- a/src/app/components/details/album_header.rs
+++ b/src/app/components/details/album_header.rs
@@ -109,7 +109,6 @@ impl AlbumHeaderWidget {
     }
 
     pub fn set_playing(&self, is_playing: bool) {
-        // TODO: still need to check if this particular album is playing
         let playback_icon = if is_playing {
             "media-playback-pause-symbolic"
         } else {

--- a/src/app/components/details/album_header.rs
+++ b/src/app/components/details/album_header.rs
@@ -1,5 +1,5 @@
-use gettextrs::gettext;
 use crate::app::components::display_add_css_provider;
+use gettextrs::gettext;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{glib, CompositeTemplate};

--- a/src/app/components/details/album_header.rs
+++ b/src/app/components/details/album_header.rs
@@ -1,3 +1,4 @@
+use gettextrs::gettext;
 use crate::app::components::display_add_css_provider;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
@@ -18,6 +19,9 @@ mod imp {
 
         #[template_child]
         pub like_button: TemplateChild<gtk::Button>,
+
+        #[template_child]
+        pub play_button: TemplateChild<gtk::Button>,
 
         #[template_child]
         pub info_button: TemplateChild<gtk::Button>,
@@ -72,6 +76,13 @@ impl AlbumHeaderWidget {
         self.imp().like_button.connect_clicked(move |_| f());
     }
 
+    pub fn connect_play<F>(&self, f: F)
+    where
+        F: Fn() + 'static,
+    {
+        self.widget().play_button.connect_clicked(move |_| f());
+    }
+
     pub fn connect_info<F>(&self, f: F)
     where
         F: Fn() + 'static,
@@ -95,6 +106,27 @@ impl AlbumHeaderWidget {
         } else {
             "non-starred-symbolic"
         });
+    }
+
+    pub fn set_playing(&self, is_playing: bool) {
+        // TODO: still need to check if this particular album is playing
+        let playback_icon = if is_playing {
+            "media-playback-pause-symbolic"
+        } else {
+            "media-playback-start-symbolic"
+        };
+
+        let translated_tooltip = if is_playing {
+            gettext("Pause")
+        } else {
+            gettext("Play")
+        };
+        let tooltip_text = Some(translated_tooltip.as_str());
+
+        let playback_control = imp::AlbumHeaderWidget::from_instance(self);
+
+        playback_control.play_button.set_icon_name(playback_icon);
+        playback_control.play_button.set_tooltip_text(tooltip_text);
     }
 
     pub fn set_artwork(&self, art: &gdk_pixbuf::Pixbuf) {

--- a/src/app/components/details/album_header.ui
+++ b/src/app/components/details/album_header.ui
@@ -104,6 +104,7 @@
         <property name="icon-name">media-playback-start-symbolic</property>
         <style>
           <class name="circular" />
+          <class name="play__button" />
         </style>
       </object>
     </child>

--- a/src/app/components/details/album_header.ui
+++ b/src/app/components/details/album_header.ui
@@ -96,6 +96,18 @@
       </object>
     </child>
     <child>
+      <object class="GtkButton" id="play_button">
+        <property name="receives-default">1</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="tooltip-text">Play</property>
+        <property name="icon-name">media-playback-start-symbolic</property>
+        <style>
+          <class name="circular" />
+        </style>
+      </object>
+    </child>
+    <child>
       <object class="GtkButton" id="like_button">
         <property name="receives-default">1</property>
         <property name="halign">center</property>

--- a/src/app/components/details/details.rs
+++ b/src/app/components/details/details.rs
@@ -12,6 +12,7 @@ use crate::app::components::{
 };
 use crate::app::dispatch::Worker;
 use crate::app::loader::ImageLoader;
+use crate::app::state::PlaybackEvent;
 use crate::app::{AppEvent, BrowserEvent};
 
 mod imp {
@@ -171,6 +172,10 @@ impl AlbumDetailsWidget {
         self.imp().header_mobile.set_liked(is_liked);
     }
 
+    fn set_playing(&self, is_playing: bool) {
+        self.widget().header_widget.set_playing(is_playing);
+    }
+
     fn set_album_and_artist_and_year(&self, album: &str, artist: &str, year: Option<u32>) {
         self.imp()
             .header_widget
@@ -265,6 +270,10 @@ impl Details {
         }
     }
 
+    fn update_playing(&self, is_playing: bool) {
+        self.widget.set_playing(is_playing);
+    }
+
     fn update_details(&mut self) {
         if let Some(album) = self.model.get_album_info() {
             let details = &album.release_details;
@@ -333,6 +342,12 @@ impl EventListener for Details {
                 if id == &self.model.id =>
             {
                 self.update_liked();
+            }
+            AppEvent::PlaybackEvent(PlaybackEvent::PlaybackPaused) => {
+                self.update_playing(false);
+            }
+            AppEvent::PlaybackEvent(PlaybackEvent::PlaybackResumed) => {
+                self.update_playing(true);
             }
             _ => {}
         }

--- a/src/app/components/details/details.rs
+++ b/src/app/components/details/details.rs
@@ -156,7 +156,7 @@ impl AlbumDetailsWidget {
     where
         F: Fn() + Clone + 'static,
     {
-        self.widget().header_widget.connect_play(f.clone());
+        self.widget().header_widget.connect_play(f);
     }
 
     fn connect_info<F>(&self, f: F)

--- a/src/app/components/details/details.rs
+++ b/src/app/components/details/details.rs
@@ -8,7 +8,7 @@ use super::release_details::ReleaseDetailsWindow;
 use super::DetailsModel;
 
 use crate::app::components::{
-    Component, EventListener, HeaderBarComponent, HeaderBarWidget, Playlist,
+    Component, EventListener, HeaderBarComponent, HeaderBarWidget, Playlist, PlaylistModel,
 };
 use crate::app::dispatch::Worker;
 use crate::app::loader::ImageLoader;
@@ -271,6 +271,10 @@ impl Details {
     }
 
     fn update_playing(&self, is_playing: bool) {
+        if !self.model.playlist_is_playing() {
+            self.widget.set_playing(false);
+            return;
+        }
         self.widget.set_playing(is_playing);
     }
 
@@ -336,6 +340,7 @@ impl EventListener for Details {
                 if id == &self.model.id =>
             {
                 self.update_details();
+                self.update_playing(true);
             }
             AppEvent::BrowserEvent(BrowserEvent::AlbumSaved(id))
             | AppEvent::BrowserEvent(BrowserEvent::AlbumUnsaved(id))

--- a/src/app/components/details/details.rs
+++ b/src/app/components/details/details.rs
@@ -151,6 +151,13 @@ impl AlbumDetailsWidget {
         self.imp().header_mobile.connect_liked(f);
     }
 
+    fn connect_play<F>(&self, f: F)
+    where
+        F: Fn() + Clone + 'static,
+    {
+        self.widget().header_widget.connect_play(f.clone());
+    }
+
     fn connect_info<F>(&self, f: F)
     where
         F: Fn() + Clone + 'static,
@@ -220,6 +227,8 @@ impl Details {
         let modal = ReleaseDetailsWindow::new();
 
         widget.connect_liked(clone!(@weak model => move || model.toggle_save_album()));
+
+        widget.connect_play(clone!(@weak model => move || model.toggle_play_album()));
 
         widget.connect_header_visibility();
 

--- a/src/app/components/details/details_model.rs
+++ b/src/app/components/details/details_model.rs
@@ -101,30 +101,35 @@ impl DetailsModel {
 
     pub fn toggle_play_album(&self) {
         if let Some(album) = self.get_album_description() {
-            let mut vec_test = Vec::new();
+            let mut all_song_ids_album = Vec::new();
             let current_song_id = self.state().playback.current_song_id();
             let playing = self.state().playback.is_playing();
             let mut album_playing = false;
-            if !current_song_id.is_none() {
-                for song_d in album.songs.songs.iter() {
-                    vec_test.push(song_d.id.as_str());
-                    if (current_song_id.as_ref().map(String::as_str).unwrap() == song_d.id.as_str())
-                        && playing
-                    {
-                        album_playing = true;
-                    }
+            let mut album_played_before = false;
+
+            for song_d in album.songs.songs.iter(){
+                all_song_ids_album.push(song_d.id.as_str());
+            } 
+
+            if !current_song_id.is_none(){
+                let song_id = current_song_id.as_ref().map(String::as_str).unwrap();
+                let current_song_playing = self.song_state(current_song_id.as_ref().map(String::as_str).unwrap()).is_playing;
+                if (all_song_ids_album.contains(&song_id)) && current_song_playing && playing{
+                    album_playing = true;
+                }else if all_song_ids_album.contains(&song_id){
+                    album_played_before = true;
                 }
             }
-            if album_playing {
-                self.dispatcher
-                    .dispatch(AppAction::PlaybackAction(PlaybackAction::Pause));
-            } else {
+
+            if album_playing{
+                self.dispatcher.dispatch(AppAction::PlaybackAction(PlaybackAction::Pause));
+            } 
+            else if album_played_before{
+                self.dispatcher.dispatch(AppAction::PlaybackAction(PlaybackAction::Play));
+            }
+            else{
                 let id_of_first_song = album.songs.songs[0].id.as_str();
-                self.play_song_at(0, id_of_first_song);
-                if !self.state().playback.is_playing() {
-                    self.dispatcher
-                        .dispatch(AppAction::PlaybackAction(PlaybackAction::Play));
-                }
+                self.play_song_at(0,id_of_first_song);
             }
         }
     }

--- a/src/app/components/details/details_model.rs
+++ b/src/app/components/details/details_model.rs
@@ -101,35 +101,21 @@ impl DetailsModel {
 
     pub fn toggle_play_album(&self) {
         if let Some(album) = self.get_album_description() {
-            let mut all_song_ids_album = Vec::new();
-            let current_song_id = self.state().playback.current_song_id();
-            let playing = self.state().playback.is_playing();
-            let mut album_playing = false;
-            let mut album_played_before = false;
-
-            for song_d in album.songs.songs.iter(){
-                all_song_ids_album.push(song_d.id.as_str());
-            } 
-
-            if !current_song_id.is_none(){
-                let song_id = current_song_id.as_ref().map(String::as_str).unwrap();
-                let current_song_playing = self.song_state(current_song_id.as_ref().map(String::as_str).unwrap()).is_playing;
-                if (all_song_ids_album.contains(&song_id)) && current_song_playing && playing{
-                    album_playing = true;
-                }else if all_song_ids_album.contains(&song_id){
-                    album_played_before = true;
+            if !self.playlist_is_playing() {
+                if self.state().playback.is_shuffled() {
+                    self.dispatcher
+                        .dispatch(AppAction::PlaybackAction(PlaybackAction::ToggleShuffle));
                 }
-            }
-
-            if album_playing{
-                self.dispatcher.dispatch(AppAction::PlaybackAction(PlaybackAction::Pause));
-            } 
-            else if album_played_before{
-                self.dispatcher.dispatch(AppAction::PlaybackAction(PlaybackAction::Play));
-            }
-            else{
                 let id_of_first_song = album.songs.songs[0].id.as_str();
-                self.play_song_at(0,id_of_first_song);
+                self.play_song_at(0, id_of_first_song);
+                return;
+            }
+            if self.state().playback.is_playing() {
+                self.dispatcher
+                    .dispatch(AppAction::PlaybackAction(PlaybackAction::Pause));
+            } else {
+                self.dispatcher
+                    .dispatch(AppAction::PlaybackAction(PlaybackAction::Play));
             }
         }
     }
@@ -206,6 +192,34 @@ impl PlaylistModel for DetailsModel {
 
     fn current_song_id(&self) -> Option<String> {
         self.state().playback.current_song_id()
+    }
+
+    fn playlist_song_ids(&self) -> Option<Vec<String>> {
+        if let Some(album) = self.get_album_description() {
+            let playlist_ids = album
+                .songs
+                .songs
+                .iter()
+                .map(|song_d| song_d.id.clone())
+                .collect::<Vec<_>>();
+            return Some(playlist_ids);
+        }
+        None
+    }
+
+    fn playlist_is_playing(&self) -> bool {
+        let current_song_id = self.state().playback.current_song_id();
+        if current_song_id.is_none() || self.playlist_song_ids().is_none() {
+            return false;
+        }
+        if self
+            .playlist_song_ids()
+            .unwrap()
+            .contains(&current_song_id.unwrap())
+        {
+            return true;
+        }
+        false
     }
 
     fn play_song_at(&self, pos: usize, id: &str) {

--- a/src/app/components/details/details_model.rs
+++ b/src/app/components/details/details_model.rs
@@ -99,6 +99,13 @@ impl DetailsModel {
         }
     }
 
+    pub fn toggle_play_album(&self) {
+        if let Some(album) = self.get_album_description() {
+            let id_of_first_song = album.songs.songs[0].id.as_str();
+            self.play_song_at(0,id_of_first_song);
+        }
+    }
+
     pub fn load_more(&self) -> Option<()> {
         let last_batch = self.song_list_model().last_batch()?;
         let query = BatchQuery {

--- a/src/app/components/playlist/playlist.rs
+++ b/src/app/components/playlist/playlist.rs
@@ -14,6 +14,14 @@ pub trait PlaylistModel {
 
     fn current_song_id(&self) -> Option<String>;
 
+    fn playlist_song_ids(&self) -> Option<Vec<String>> {
+        None
+    }
+
+    fn playlist_is_playing(&self) -> bool {
+        false
+    }
+
     fn play_song_at(&self, pos: usize, id: &str);
 
     fn autoscroll_to_playing(&self) -> bool {

--- a/src/app/components/playlist_details/playlist_details.rs
+++ b/src/app/components/playlist_details/playlist_details.rs
@@ -4,7 +4,7 @@ use gtk::CompositeTemplate;
 use std::rc::Rc;
 
 use super::PlaylistDetailsModel;
-use crate::app::components::AlbumHeaderWidget;
+use crate::app::components::{AlbumHeaderWidget, PlaylistModel};
 
 use crate::app::components::{Component, EventListener, Playlist};
 use crate::app::dispatch::Worker;
@@ -218,6 +218,10 @@ impl PlaylistDetails {
     }
 
     fn update_playing(&self, is_playing: bool) {
+        if !self.model.playlist_is_playing() {
+            self.widget.set_playing(false);
+            return;
+        }
         self.widget.set_playing(is_playing);
     }
 }
@@ -238,7 +242,8 @@ impl EventListener for PlaylistDetails {
             AppEvent::BrowserEvent(BrowserEvent::PlaylistDetailsLoaded(id))
                 if id == &self.model.id =>
             {
-                self.update_details()
+                self.update_details();
+                self.update_playing(true);
             }
             AppEvent::PlaybackEvent(PlaybackEvent::PlaybackPaused) => {
                 self.update_playing(false);

--- a/src/app/components/saved_tracks/saved_tracks_model.rs
+++ b/src/app/components/saved_tracks/saved_tracks_model.rs
@@ -82,7 +82,7 @@ impl PlaylistModel for SavedTracksModel {
                 .dispatch(PlaybackAction::Load(id.to_string()).into());
         }
     }
-    
+
     fn autoscroll_to_playing(&self) -> bool {
         true
     }

--- a/src/app/components/saved_tracks/saved_tracks_model.rs
+++ b/src/app/components/saved_tracks/saved_tracks_model.rs
@@ -82,6 +82,7 @@ impl PlaylistModel for SavedTracksModel {
                 .dispatch(PlaybackAction::Load(id.to_string()).into());
         }
     }
+    
     fn autoscroll_to_playing(&self) -> bool {
         true
     }


### PR DESCRIPTION
This PR fixes issue #493.

**Implementation details:**
I implemented a play button for albums and playlists, similar to the one in Spotify.
The button is shown in the header bar next to the starring button.
![image](https://user-images.githubusercontent.com/60743257/199192085-fa8cf103-3e79-4131-bf3c-18383da4d958.png)
- When the button is clicked, the first song of the playlist/ album is played. After that, the button icon changes to the 'pause-icon'.
- If the playlist is paused and then the play button is clicked again, the currently playing track will be resumed.
- If track T is part of playlist P and T is started from a different place, P will show the 'pause-icon' as a track of this playlist is currently playing
- Shuffle is disabled, when playing a playlist/ album.