### PR TITLE
fix overlap between timestamp and long song title

### DIFF
--- a/src/app/components/playlist/song.ui
+++ b/src/app/components/playlist/song.ui
@@ -67,7 +67,7 @@
         <property name="yalign">1</property>
         <property name="hexpand">1</property>
         <layout>
-          <property name="column-span">3</property>
+          <property name="column-span">2</property>
           <property name="column">1</property>
           <property name="row">0</property>
         </layout>


### PR DESCRIPTION
Fix [issue#538](https://github.com/xou816/spot/issues/538).

`column-span` for song_title was set to `3`, led to the overlap with song_length. It is fixed by reducing the field to `2`.

## Screenshot

![image](https://user-images.githubusercontent.com/38270878/219352675-0c7345fa-6935-45c1-bae3-093c13e18b99.png)
