### PR TITLE
Fix autologin when password contains backslashes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Warren Hu
 bbb651
 Julius Rüberg
 janbrummer
+Sam Al-Sapti

--- a/src/app/credentials.rs
+++ b/src/app/credentials.rs
@@ -35,7 +35,7 @@ impl Credentials {
         }
         let items = collection.search_items(make_attributes()).await?;
         let item = items.get(0).ok_or(Error::NoResult)?.get_secret().await?;
-        // We need to escape backslashes in order to correctnly deserialize passwords that contain backslashes
+        // We need to escape backslashes in order to correctly deserialize passwords that contain backslashes
         let secret = String::from_utf8(item)
             .map_err(|_| Error::NoResult)?
             .replace("\\", "\\\\");

--- a/src/app/credentials.rs
+++ b/src/app/credentials.rs
@@ -36,7 +36,9 @@ impl Credentials {
         let items = collection.search_items(make_attributes()).await?;
         let item = items.get(0).ok_or(Error::NoResult)?.get_secret().await?;
         // We need to escape backslashes in order to correctnly deserialize passwords that contain backslashes
-        let secret = String::from_utf8(item).map_err(|_| Error::NoResult)?.replace("\\", "\\\\");
+        let secret = String::from_utf8(item)
+            .map_err(|_| Error::NoResult)?
+            .replace("\\", "\\\\");
         serde_json::from_str(secret.as_str()).map_err(|_| Error::NoResult)
     }
 

--- a/src/app/credentials.rs
+++ b/src/app/credentials.rs
@@ -35,7 +35,9 @@ impl Credentials {
         }
         let items = collection.search_items(make_attributes()).await?;
         let item = items.get(0).ok_or(Error::NoResult)?.get_secret().await?;
-        serde_json::from_slice(&item).map_err(|_| Error::Unavailable)
+        // We need to escape backslashes in order to correctnly deserialize passwords that contain backslashes
+        let secret = String::from_utf8(item).map_err(|_| Error::NoResult)?.replace("\\", "\\\\");
+        serde_json::from_str(secret.as_str()).map_err(|_| Error::NoResult)
     }
 
     pub async fn logout() -> Result<(), Error> {


### PR DESCRIPTION
This PR fixes #596. I also changed the error type returned by `Credentials::retrieve()` from `Error::Unavailable` to `Error::NoResult`, as it seems more appropriate for when the secret can't be read.
