### PR TITLE
Use libadwaita::AboutWindow instead of gtk::AboutDialog

### DIFF
--- a/src/app/components/user_menu/user_menu.rs
+++ b/src/app/components/user_menu/user_menu.rs
@@ -16,7 +16,7 @@ impl UserMenu {
     pub fn new(
         user_button: gtk::MenuButton,
         settings: Settings,
-        about: gtk::AboutDialog,
+        about: libadwaita::AboutWindow,
         model: UserMenuModel,
     ) -> Self {
         let model = Rc::new(model);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -208,7 +208,7 @@ impl App {
         let settings = Settings::new(parent, settings_model);
 
         let button: gtk::MenuButton = builder.object("user").unwrap();
-        let about: gtk::AboutDialog = builder.object("about").unwrap();
+        let about: libadwaita::AboutWindow = builder.object("about").unwrap();
         let model = UserMenuModel::new(app_model, dispatcher);
         let user_menu = UserMenu::new(button, settings, about, model);
         Box::new(user_menu)

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
     let sender = dispatch_loop.make_dispatcher();
 
     register_actions(&gtk_app, sender.clone());
-    setup_credits(builder.object::<gtk::AboutDialog>("about").unwrap());
+    setup_credits(builder.object::<libadwaita::AboutWindow>("about").unwrap());
 
     let app = App::new(
         settings,
@@ -112,7 +112,7 @@ fn setup_gtk(settings: &settings::SpotSettings) {
     );
 }
 
-fn setup_credits(about: gtk::AboutDialog) {
+fn setup_credits(about: libadwaita::AboutWindow) {
     let authors: Vec<&str> = include_str!("../AUTHORS")
         .trim_end_matches('\n')
         .split('\n')
@@ -122,9 +122,9 @@ fn setup_credits(about: gtk::AboutDialog) {
         .trim_end_matches('\n')
         .split('\n')
         .collect();
-    about.set_version(Some(config::VERSION));
-    about.set_authors(&authors);
-    about.set_translator_credits(Some(translators));
+    about.set_version(config::VERSION);
+    about.set_developers(&authors);
+    about.set_translator_credits(translators);
     about.set_artists(&artists);
 }
 

--- a/src/window.blp
+++ b/src/window.blp
@@ -123,12 +123,12 @@ Adw.ApplicationWindow window {
   }
 }
 
-AboutDialog about {
+Adw.AboutWindow about {
   modal: true;
   destroy-with-parent: true;
   transient-for: window;
-  program-name: "Spot";
+  application-name: "Spot";
   website: "https://github.com/xou816/spot";
-  logo-icon-name: "dev.alextren.Spot";
+  application-icon: "dev.alextren.Spot";
   license-type: mit_x11;
 }


### PR DESCRIPTION
Switched to libadwaita's AboutWindow as mentioned in Issue #636.

I believe I've done it correctly, but I'm still quite the n00b in GTK4 and Rust, so here's a screenshot of the new about page that this PR creates: 

![new about screen](https://i.imgur.com/1AlOS0x.png)