### PR TITLE
update subproject blueprint-compiler to v0.8.1

### DIFF
--- a/subprojects/blueprint-compiler.wrap
+++ b/subprojects/blueprint-compiler.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 directory = blueprint-compiler
 url = https://gitlab.gnome.org/jwestman/blueprint-compiler.git
-revision = v0.6.0
+revision = v0.8.1
 depth = 1
 
 [provide]


### PR DESCRIPTION
e.g. Debian only has blueprint-compiler v0.6.0, and the current wrapper spec is v0.6.0 but the project requires v0.8.1