### PR TITLE
Improve cover button display in library

### DIFF
--- a/src/app/components/album/album.blp
+++ b/src/app/components/album/album.blp
@@ -5,6 +5,7 @@ template $AlbumWidget : Adw.Bin {
   Button cover_btn {
     hexpand: false;
     halign: center;
+    valign: start;
 
     Box {
       halign: center;

--- a/src/app/components/library/library.blp
+++ b/src/app/components/library/library.blp
@@ -5,7 +5,7 @@ template $LibraryWidget : Box {
   ScrolledWindow scrolled_window {
     hexpand: true;
     vexpand: true;
-    vscrollbar-policy: always;
+    vscrollbar-policy: automatic;
     min-content-width: 250;
     Overlay overlay {
       FlowBox flowbox {


### PR DESCRIPTION
If there are few albums in library then cover button expands down to the box bottom border. That does not happen in other places for some reason. Also scrollbar in library should not be always displayed, as it does not make sense for the case with few albums.
Before:
![Screenshot from 2023-08-01 01-36-52](https://github.com/xou816/spot/assets/3534692/1c01513d-a3f3-46ba-9d44-18f41ef8fdf3)
After:
![Screenshot from 2023-08-01 02-24-03](https://github.com/xou816/spot/assets/3534692/a72724f1-5254-4e78-963f-b3878fbcf231)
