### PR TITLE
Fix playlist loading

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ bbb651
 Julius Rüberg
 janbrummer
 Alisson Lauffer
+Riley Smith

--- a/src/api/api_models.rs
+++ b/src/api/api_models.rs
@@ -186,7 +186,7 @@ trait WithImages {
 pub struct Playlist {
     pub id: String,
     pub name: String,
-    pub images: Vec<Image>,
+    pub images: Option<Vec<Image>>,
     pub tracks: Page<PlaylistTrack>,
     pub owner: PlaylistOwner,
 }
@@ -199,7 +199,11 @@ pub struct PlaylistOwner {
 
 impl WithImages for Playlist {
     fn images(&self) -> &[Image] {
-        &self.images[..]
+        if let Some(ref images) = self.images {
+            images
+        } else {
+            &[]
+        }
     }
 }
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -388,12 +388,9 @@ impl SpotifyClient {
     pub(crate) fn get_playlist(&self, id: &str) -> SpotifyRequest<'_, (), Playlist> {
         let query = make_query_params()
             .append_pair("market", "from_token")
-            // why still grab the tracks field? 
+            // why still grab the tracks field?
             // the model still expects the appearance of a tracks field
-            .append_pair(
-                "fields",
-                "id,name,images,owner,tracks(total)",
-            )
+            .append_pair("fields", "id,name,images,owner,tracks(total)")
             .finish();
         self.request()
             .method(Method::GET)

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -387,9 +387,10 @@ impl SpotifyClient {
 
     pub(crate) fn get_playlist(&self, id: &str) -> SpotifyRequest<'_, (), Playlist> {
         let query = make_query_params()
+            .append_pair("market", "from_token")
             .append_pair(
                 "fields",
-                "id,name,images,owner,tracks(total,items(is_local,track(name,id,uri,duration_ms,artists(name,id),album(name,id,images,artists))))",
+                "id,name,images,owner,tracks(total,items(is_local,track(name,id,uri,duration_ms,album,artists(name,id))))",
             )
             .finish();
         self.request()
@@ -404,6 +405,7 @@ impl SpotifyClient {
         limit: usize,
     ) -> SpotifyRequest<'_, (), Page<PlaylistTrack>> {
         let query = make_query_params()
+            .append_pair("market", "from_token")
             .append_pair("offset", &offset.to_string()[..])
             .append_pair("limit", &limit.to_string()[..])
             .finish();

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -388,9 +388,11 @@ impl SpotifyClient {
     pub(crate) fn get_playlist(&self, id: &str) -> SpotifyRequest<'_, (), Playlist> {
         let query = make_query_params()
             .append_pair("market", "from_token")
+            // why still grab the tracks field? 
+            // the model still expects the appearance of a tracks field
             .append_pair(
                 "fields",
-                "id,name,images,owner,tracks(total,items(is_local,track(name,id,uri,duration_ms,album,artists(name,id))))",
+                "id,name,images,owner,tracks(total)",
             )
             .finish();
         self.request()

--- a/src/app/components/playlist_details/playlist_details_model.rs
+++ b/src/app/components/playlist_details/playlist_details_model.rs
@@ -82,9 +82,10 @@ impl PlaylistDetailsModel {
         self.dispatcher
             .call_spotify_and_dispatch(move || async move {
                 let playlist = api.get_playlist(&id).await;
+                let playlist_tracks = api.get_playlist_tracks(&id, 0, 100).await?;
                 match playlist {
                     Ok(playlist) => {
-                        Ok(BrowserAction::SetPlaylistDetails(Box::new(playlist)).into())
+                        Ok(BrowserAction::SetPlaylistDetails(Box::new(playlist), Box::new(playlist_tracks)).into())
                     }
                     Err(SpotifyApiError::BadStatus(400, _))
                     | Err(SpotifyApiError::BadStatus(404, _)) => {
@@ -108,7 +109,7 @@ impl PlaylistDetailsModel {
         let loader = self.app_model.get_batch_loader();
 
         self.dispatcher.dispatch_async(Box::pin(async move {
-            loader
+            loader 
                 .query(next_query, |_s, song_batch| {
                     BrowserAction::AppendPlaylistTracks(id, Box::new(song_batch)).into()
                 })

--- a/src/app/components/playlist_details/playlist_details_model.rs
+++ b/src/app/components/playlist_details/playlist_details_model.rs
@@ -68,8 +68,7 @@ impl PlaylistDetailsModel {
                 if playlist.songs.songs.is_empty() {
                     error!("Unable to start playback because songs is empty");
                     self.dispatcher
-                        .dispatch(
-                        AppAction::ShowNotification(gettext(
+                        .dispatch(AppAction::ShowNotification(gettext(
                             "An error occured. Check logs for details!",
                         )));
                     return;
@@ -97,9 +96,11 @@ impl PlaylistDetailsModel {
                 let playlist = api.get_playlist(&id).await;
                 let playlist_tracks = api.get_playlist_tracks(&id, 0, 100).await?;
                 match playlist {
-                    Ok(playlist) => {
-                        Ok(BrowserAction::SetPlaylistDetails(Box::new(playlist), Box::new(playlist_tracks)).into())
-                    }
+                    Ok(playlist) => Ok(BrowserAction::SetPlaylistDetails(
+                        Box::new(playlist),
+                        Box::new(playlist_tracks),
+                    )
+                    .into()),
                     Err(SpotifyApiError::BadStatus(400, _))
                     | Err(SpotifyApiError::BadStatus(404, _)) => {
                         Ok(BrowserAction::NavigationPop.into())

--- a/src/app/state/browser_state.rs
+++ b/src/app/state/browser_state.rs
@@ -19,7 +19,7 @@ pub enum BrowserAction {
     RemoveTracksFromPlaylist(String, Vec<String>),
     SetAlbumDetails(Box<AlbumFullDescription>),
     AppendAlbumTracks(String, Box<SongBatch>),
-    SetPlaylistDetails(Box<PlaylistDescription>),
+    SetPlaylistDetails(Box<PlaylistDescription>, Box<SongBatch>),
     UpdatePlaylistName(PlaylistSummary),
     AppendPlaylistTracks(String, Box<SongBatch>),
     Search(String),

--- a/src/app/state/screen_states.rs
+++ b/src/app/state/screen_states.rs
@@ -119,9 +119,9 @@ impl UpdatableState for PlaylistDetailsState {
 
     fn update_with(&mut self, action: Cow<Self::Action>) -> Vec<Self::Event> {
         match action.as_ref() {
-            BrowserAction::SetPlaylistDetails(playlist) if playlist.id == self.id => {
-                let PlaylistDescription { id, songs, .. } = *playlist.clone();
-                self.songs.add(songs).commit();
+            BrowserAction::SetPlaylistDetails(playlist, song_batch) if playlist.id == self.id => {
+                let PlaylistDescription { id, .. } = *playlist.clone();
+                self.songs.add(*song_batch.clone()).commit();
                 self.playlist = Some(*playlist.clone());
                 vec![BrowserEvent::PlaylistDetailsLoaded(id)]
             }


### PR DESCRIPTION
## This PR seeks to fix Spot's ability to load playlists.

Sometime around December 16th, Spotify broke the query string fields argument (#689). It now seems to be impossible to filter specific fields from larger objects. E.G. the artists field and albums field. Current behavior sees Spotify not returning the objects requested and depending on the order of the artists and albums field one will get returned while the other is not.

I spent a few hours messing around with the query string arguments and found a solution by not filtering the albums field
which is seen here: https://github.com/xou816/spot/commit/56cf43625a1dc281daef3f74924d21d4a4a324bd
```diff
--- id,name,images,owner,tracks(total,items(is_local,track(name,id,uri,duration_ms,artists(name,id),album(name,id,images,artists)))) 
+++ id,name,images,owner,tracks(total,items(is_local,track(name,id,uri,duration_ms,album,artists(name,id))))
```

While this did fix the loading bug, it causes a lot more data to be sent than needed... So instead, it calls get_playlist_tracks in the initial loading of a playlist and separately add the song batch from that API call to the playlists song state.

## Other Fixes
Spot crashing if a user tries to play a playlist with no songs
Spot erroring if a user loads a playlist with no image

Note: I am more than happy to split these other fixes into multiple PRs if needed.