### PR TITLE
Bug Fix: Handle null images for playlist

### DIFF
--- a/src/api/api_models.rs
+++ b/src/api/api_models.rs
@@ -203,7 +203,6 @@ const EMPTY_IMAGE: &'static [Image] = &[Image {
     width: Some(640),
 }];
 
-
 impl WithImages for Playlist {
     fn images(&self) -> &[Image] {
         match &self.images {

--- a/src/api/api_models.rs
+++ b/src/api/api_models.rs
@@ -186,7 +186,7 @@ trait WithImages {
 pub struct Playlist {
     pub id: String,
     pub name: String,
-    pub images: Vec<Image>,
+    pub images: Option<Vec<Image>>,
     pub tracks: Page<PlaylistTrack>,
     pub owner: PlaylistOwner,
 }
@@ -197,9 +197,14 @@ pub struct PlaylistOwner {
     pub display_name: String,
 }
 
+const def_image: &'static [Image] = &[Image {url: String::new(), height: Some(640), width: Some(640)}];
+
 impl WithImages for Playlist {
     fn images(&self) -> &[Image] {
-        &self.images[..]
+        match &self.images {
+            Some(x) => &x[..],
+            None => &def_image[..],
+        }
     }
 }
 

--- a/src/api/api_models.rs
+++ b/src/api/api_models.rs
@@ -197,13 +197,18 @@ pub struct PlaylistOwner {
     pub display_name: String,
 }
 
-const def_image: &'static [Image] = &[Image {url: String::new(), height: Some(640), width: Some(640)}];
+const EMPTY_IMAGE: &'static [Image] = &[Image {
+    url: String::new(),
+    height: Some(640),
+    width: Some(640),
+}];
+
 
 impl WithImages for Playlist {
     fn images(&self) -> &[Image] {
         match &self.images {
             Some(x) => &x[..],
-            None => &def_image[..],
+            None => &EMPTY_IMAGE[..],
         }
     }
 }


### PR DESCRIPTION
Fixes #715, potentially #713 

If a user has a playlist with no image (due to only local songs, no songs in playlist, etc), Spotify API returns a null for image and causes Spot to fail loading any playlist changes.

This turns images to an option and, if null, returns an empty image instead. It is a quick and dirty fix, but I do not know much Rust, so I've done what I could.

Thank you in advance.

@xou816