### PR TITLE
Fix: handle empty playlist images from API response

### DIFF
--- a/src/api/api_models.rs
+++ b/src/api/api_models.rs
@@ -173,7 +173,7 @@ trait WithImages {
             .map(|image| (criterion(image), image))
             .collect::<Vec<(T, &Image)>>();
 
-        ords.sort_by(|a, b| (a.0).partial_cmp(&b.0).unwrap());
+        ords.sort_by(|a, b| (a.0).partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
         Some(ords.first()?.1)
     }
 
@@ -186,7 +186,7 @@ trait WithImages {
 pub struct Playlist {
     pub id: String,
     pub name: String,
-    pub images: Vec<Image>,
+    pub images: Option<Vec<Image>>,
     pub tracks: Page<PlaylistTrack>,
     pub owner: PlaylistOwner,
 }
@@ -199,7 +199,7 @@ pub struct PlaylistOwner {
 
 impl WithImages for Playlist {
     fn images(&self) -> &[Image] {
-        &self.images
+    self.images.as_deref().unwrap_or_default()
     }
 }
 

--- a/src/app/components/playlist_details/playlist_details.rs
+++ b/src/app/components/playlist_details/playlist_details.rs
@@ -129,6 +129,10 @@ impl PlaylistDetailsWidget {
         self.imp().header_widget.set_playing(is_playing);
     }
 
+    fn set_fallback_artwork(&self) {
+        self.imp().header_widget.imp().playlist_art.set_icon_name(Some("audio-x-generic-symbolic"));
+    }
+
     fn set_artwork(&self, art: &gdk_pixbuf::Pixbuf) {
         self.imp().header_widget.set_artwork(art);
     }
@@ -270,7 +274,7 @@ impl PlaylistDetails {
         }
     }
 
-    fn update_details(&self) {
+    fn update_details(&mut self) {
         if let Some(info) = self.model.get_playlist_info() {
             let title = &info.title[..];
             let owner = &info.owner.display_name[..];
@@ -279,17 +283,22 @@ impl PlaylistDetails {
             self.widget.set_info(title, owner);
 
             if let Some(art_url) = art_url.cloned() {
-                let widget = self.widget.downgrade();
+                let widget_clone = self.widget.downgrade();
                 self.worker.send_local_task(async move {
                     let pixbuf = ImageLoader::new()
                         .load_remote(&art_url[..], "jpg", 320, 320)
                         .await;
-                    if let (Some(widget), Some(ref pixbuf)) = (widget.upgrade(), pixbuf) {
-                        widget.set_artwork(pixbuf);
+                    if let Some(widget) = widget_clone.upgrade() {
+                        if let Some(ref pixbuf) = pixbuf {
+                            widget.set_artwork(pixbuf);
+                        } else {
+                            widget.set_fallback_artwork();
+                        }
                         widget.set_loaded();
                     }
                 });
             } else {
+                self.widget.set_fallback_artwork();
                 self.widget.set_loaded();
             }
         }


### PR DESCRIPTION
Hi,
I tried to fix the bug in #738. The problem is that the Web API may return null for images (That happens if the playlist doesn't have any songs yet for example). The behaviour is described in their [API reference](https://developer.spotify.com/documentation/web-api/reference/get-playlist). I tested it locally and for me the changes do the trick. I used a default Icon as a place holder, should be fine I think. 

As I am not really experienced in Rust nor in contributing to public code I would very welcome constructive feedback :)