### PR TITLE
Add multi-arch Flatpak CI builds with ARM64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: spot-flatpak-multiarch
+
+on:
+  push:
+    branches: [master, development]
+    paths-ignore:
+      - '*.md'
+  pull_request:
+    branches: [master, development]
+  workflow_dispatch:
+
+jobs:
+  flatpak:
+    name: "Flatpak ${{ matrix.variant.arch }}"
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-47
+      options: --privileged
+    strategy:
+      matrix:
+        variant:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.variant.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: spot-${{ matrix.variant.arch }}.flatpak
+          manifest-path: dev.alextren.Spot.snapshots.json
+          cache-key: flatpak-builder-${{ matrix.variant.arch }}-${{ github.sha }}
+          arch: ${{ matrix.variant.arch }}
+
+  release:
+    name: "Create Release"
+    needs: [flatpak]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/development')
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+    
+    - name: Prepare release files
+      run: |
+        mkdir -p release-files
+        find artifacts -type f -name "*.flatpak" | while read file; do
+          cp "$file" release-files/
+        done
+        ls -la release-files/
+    
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: "${{ github.ref == 'refs/heads/master' && 'latest' || 'development' }}-${{ github.run_number }}"
+        name: "Spot ${{ github.ref == 'refs/heads/master' && 'Release' || 'Development' }} Build #${{ github.run_number }}"
+        body: |
+          Automated build from ${{ github.ref_name }} branch
+          
+          ## Downloads
+          - `spot-x86_64.flatpak` - x86_64 build  
+          - `spot-aarch64.flatpak` - ARM64 build (postmarketOS, PinePhone, etc.)
+        generate_release_notes: true
+        files: release-files/*.flatpak
+        make_latest: ${{ github.ref == 'refs/heads/master' }}
+        prerelease: ${{ github.ref == 'refs/heads/development' }}
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes https://github.com/xou816/spot/issues/751

Testing is requried, it automatically creates releases using the softprops/action-gh-release github action
I tested on postmarketOS, altough I had to run these commands first to fix GPG issues and install gnome 47

```
flatpak remote-delete flathub
flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
```
```
flatpak install flathub org.gnome.Platform//47
```